### PR TITLE
Run RabbitMQ in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,6 @@ jobs:
         ruby-version: 3.0.0
     - name: Run the default task
       run: |
-        gem install bundler -v 2.2.15
         bundle install
         bundle exec rake
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,16 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['2.7', '3.0']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0.0
+        ruby-version: ${{ matrix.ruby }}
     - name: Run the default task
       run: |
         bundle install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,17 @@ on: [push,pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+        - 5672/tcp
+        # needed because the rabbitmq container does not provide a healthcheck
+        options: >-
+          --health-cmd "rabbitmqctl node_health_check"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -16,3 +27,6 @@ jobs:
         gem install bundler -v 2.2.15
         bundle install
         bundle exec rake
+      env:
+        AMQP_PORT: ${{ job.services.rabbitmq.ports[5672] }}
+

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -15,7 +15,7 @@ module AMQP
     def initialize(uri)
       @uri = URI.parse(uri)
       @tls = @uri.scheme == "amqps"
-      @port = @uri.port || @tls ? 5671 : 5672
+      @port = port_from_env || @uri.port || (@tls ? 5671 : 5672)
       @host = @uri.host || "localhost"
       @user = @uri.user || "guest"
       @password = @uri.password || "guest"
@@ -96,6 +96,12 @@ module AMQP
       socket.setsockopt(Socket::SOL_TCP, Socket::TCP_KEEPCNT, 3)
     rescue => e
       warn "amqp-client: Could not enable TCP keepalive on socket. #{e.inspect}"
+    end
+
+    def port_from_env
+      port = ENV["AMQP_PORT"]
+
+      port.nil? ? nil : port.to_i
     end
   end
 end


### PR DESCRIPTION
Use ENV to control the port used, did the minimum to get the tests
running, thinking we can support reading more parts of the URI from ENV
later.

There was a bug in the statement that assigned the port instance
variable, || has higher precedence than the ternary operator so Ruby
interpreted the old code as

    (@uri.port || @tls) ? 5671 : 5672

which worked as expected as long as both variables where nil.