### PR TITLE
Rescue Errno::ECONNREFUSED error

### DIFF
--- a/lib/amqp/client/connection.rb
+++ b/lib/amqp/client/connection.rb
@@ -400,7 +400,7 @@ module AMQP
           socket.post_connection_check(host) || raise(Error, "TLS certificate hostname doesn't match requested")
         end
         socket
-      rescue Errno::ECONNREFUSED => e
+      rescue SystemCallError, OpenSSL::OpenSSLError => e
         raise Error, "Could not open a socket: #{e.message}"
       end
 

--- a/lib/amqp/client/connection.rb
+++ b/lib/amqp/client/connection.rb
@@ -400,6 +400,8 @@ module AMQP
           socket.post_connection_check(host) || raise(Error, "TLS certificate hostname doesn't match requested")
         end
         socket
+      rescue Errno::ECONNREFUSED => e
+        raise Error, "Could not open a socket: #{e.message}"
       end
 
       # Negotiate a connection


### PR DESCRIPTION
Current PR adds the possibility for the high-level API to reconnect if smth went wrong with RabbitMQ (e.g restart).

Steps to reproduce the problem:
1. Open an AMQP connection using the high level API
2. Restart RabbitMQ (e.g `brew services restart rabbitmq` on OSX)