### PR TITLE
CI: add macOS job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,27 @@ jobs:
       env:
         TESTOPTS: --exclude=/_tls$/
         AMQP_PORT: ${{ job.services.rabbitmq.ports[5672] }}
+  macos:
+    runs-on: macos-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.0']
+    steps:
+    - name: Install RabbitMQ
+      run: brew install rabbitmq
+    - name: Start RabbitMQ
+      run: brew services start rabbitmq
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: ${{ matrix.ruby }}
+    - name: Verify RabbitMQ started correctly
+      run: while true; do rabbitmq-diagnostics status 2>/dev/null && break; echo -n .; sleep 2; done
+    - name: Run the default task
+      run: bundle exec rake
+      env:
+        TESTOPTS: --exclude=/_tls$/


### PR DESCRIPTION
Installs RabbitMQ using Homebrew. Probably don't need to test all Ruby versions on macOS?

We save some wait time by installing and starting RabbitMQ before code checkout and ruby setup.