### PR TITLE
CI: Only run RuboCop on CRuby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,4 +15,4 @@ RuboCop::RakeTask.new do |task|
   task.requires << "rubocop-minitest"
 end
 
-task default: %i[test rubocop]
+task default: [:test, *(:rubocop if RUBY_ENGINE == "ruby")]


### PR DESCRIPTION
Redundant with running it on CRuby and makes for slower builds. Common for TruffleRuby to have problems with RuboCop. References: https://github.com/puma/puma/pull/2737, https://github.com/puma/puma/pull/2198#discussion_r396870521