### PR TITLE
Exclude the TLS tests by default, run in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Ruby
 on: [push,pull_request]
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     services:
@@ -36,6 +36,50 @@ jobs:
       run: bundle exec rake
       env:
         AMQP_PORT: ${{ job.services.rabbitmq.ports[5672] }}
+  tls:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.0', 'jruby', 'truffleruby']
+    steps:
+    - name: Install RabbitMQ
+      run: sudo apt-get update && sudo apt-get install -y rabbitmq-server
+    - name: Stop RabbitMQ
+      run: sudo systemctl stop rabbitmq-server
+
+    - name: Install github.com/FiloSottile/mkcert
+      run: brew install mkcert
+    - name: Create local CA
+      run: sudo CAROOT=/etc/rabbitmq $(brew --prefix)/bin/mkcert -install
+    - name: Create certificate
+      run: |
+        sudo $(brew --prefix)/bin/mkcert -key-file /etc/rabbitmq/localhost-key.pem -cert-file /etc/rabbitmq/localhost.pem localhost
+        sudo chmod +r /etc/rabbitmq/localhost-key.pem
+    - name: Create RabbitMQ config
+      run: |
+        sudo tee /etc/rabbitmq/rabbitmq.conf <<'EOF'
+        listeners.ssl.default  = 5671
+        ssl_options.cacertfile = /etc/rabbitmq/rootCA.pem
+        ssl_options.certfile   = /etc/rabbitmq/localhost.pem
+        ssl_options.keyfile    = /etc/rabbitmq/localhost-key.pem
+        EOF
+    - name: Start RabbitMQ
+      run: sudo systemctl start rabbitmq-server
+    - name: Verify RabbitMQ started correctly
+      run: while true; do sudo rabbitmq-diagnostics status 2>/dev/null && break; echo -n .; sleep 2; done
+
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: ${{ matrix.ruby }}
+    - name: Run TLS tests
+      run: bundle exec rake
+      env:
+        TESTOPTS: --name=/_tls$/
   macos:
     runs-on: macos-latest
     timeout-minutes: 5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,6 @@ jobs:
       continue-on-error: ${{ matrix.allow-failure || false }}
       run: bundle exec rake
       env:
-        TESTOPTS: --exclude=/_tls$/
         AMQP_PORT: ${{ job.services.rabbitmq.ports[5672] }}
   macos:
     runs-on: macos-latest
@@ -59,5 +58,3 @@ jobs:
       run: while true; do rabbitmq-diagnostics status 2>/dev/null && break; echo -n .; sleep 2; done
     - name: Run tests (excluding TLS tests)
       run: bundle exec rake
-      env:
-        TESTOPTS: --exclude=/_tls$/

--- a/Rakefile
+++ b/Rakefile
@@ -4,9 +4,16 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.description = "Run all but TLS tests"
+  t.options = "--exclude=/_tls$/"
+  t.pattern = "test/**/*_test.rb"
+end
+
+namespace :test do
+  Rake::TestTask.new(:all) do |t|
+    t.description = "Run all tests"
+    t.pattern = "test/**/*_test.rb"
+  end
 end
 
 require "rubocop/rake_task"


### PR DESCRIPTION
Most people ~~(and CI)~~ can't run the TLS tests right now, I think it makes
sense to exclude them by default. The TESTOPTS thing isn't that easy to
remember.

Added `rake test:all` to run them.