### PR TITLE
Add "bundler/setup" to Rakefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}
     - name: Run the default task
-      run: bundle exec rake
+      run: rake
       env:
         TESTOPTS: --exclude=/_tls$/
         AMQP_PORT: ${{ job.services.rabbitmq.ports[5672] }}
@@ -54,6 +54,6 @@ jobs:
     - name: Verify RabbitMQ started correctly
       run: while true; do rabbitmq-diagnostics status 2>/dev/null && break; echo -n .; sleep 2; done
     - name: Run the default task
-      run: bundle exec rake
       env:
         TESTOPTS: --exclude=/_tls$/
+      run: rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bundler/setup"
 require "bundler/gem_tasks"
 require "rake/testtask"
 


### PR DESCRIPTION
Allows one to skip typing "bundle exec" and should speed up
JRuby/TruffleRuby, from https://github.com/jruby/jruby/wiki/Improving-startup-time#bundle-exec

> Bundler's "exec" command causes a second JRuby instance to be launched
> for the sole purpose of booting only your Gemfile gems.