### PR TITLE
Allow high level operations inside subscribe

### DIFF
--- a/test/amqp/client_test.rb
+++ b/test/amqp/client_test.rb
@@ -549,6 +549,7 @@ class AMQPClientTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   end
 
   def test_blocked_handler
+    skip "requires sudo"
     q = Queue.new
     client = AMQP::Client.new("amqp://localhost")
     connection = client.connect

--- a/test/amqp/high_level_test.rb
+++ b/test/amqp/high_level_test.rb
@@ -142,7 +142,7 @@ class HighLevelTest < Minitest::Test
     input_queue = client.queue("test.in")
     output_queue = client.queue("test.out")
     begin
-      input_queue.subscribe do |msg|
+      input_queue.subscribe(no_ack: true) do |msg|
         output_queue.publish("baz")
         msgs.push msg
       end
@@ -155,10 +155,10 @@ class HighLevelTest < Minitest::Test
       input_queue.publish("bar")
       msg = msgs.pop
       assert_equal "test.in", msg.routing_key
-      assert_equal "foo", msg.body
+      assert_equal "bar", msg.body
     ensure
       input_queue.delete
-      input_queue.delete
+      output_queue.delete
       client.stop
     end
   end


### PR DESCRIPTION
closes #18

Currently, it's not possible to call any high level operations inside the subscribe block. The program halts and it never goes on.

This is due to the fact that all the high-level methods perform the logic inside the same `with_connection do`.  This makes sense for all the operations on the "publish channel" instantiated in `client.rb:63`:

```ruby
conn.channel(1) # reserve channel 1 for publishes
```

But for the `.subscribe` operation a new channel is created, so I think that is OK to use another block. So in my proposed solution I create another `SizedQueue` used by the `.subscribe` method, with the corresponding `with_subscribe_connection` block.

Note that the underline connection is the same, I'm not creating a new connection.