### PR TITLE
Fix broken TLS tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ jobs:
     - name: Stop RabbitMQ
       run: sudo systemctl stop rabbitmq-server
 
+    - name: Set up Homebrew
+      uses: Homebrew/actions/setup-homebrew@master
     - name: Install github.com/FiloSottile/mkcert
       run: brew install mkcert
     - name: Create local CA


### PR DESCRIPTION
`brew` was removed from `$PATH` on Ubuntu runners, see https://github.com/actions/runner-images/issues/6283.