### PR TITLE
Confirm bug fix

### DIFF
--- a/test/amqp/tls_test.rb
+++ b/test/amqp/tls_test.rb
@@ -31,11 +31,11 @@ class AMQPSClientTest < Minitest::Test
     10_000.times do |i|
       ch2.basic_publish "bar #{i + 1}", "amq.topic", "foo"
     end
+    ch2.wait_for_confirms
 
     10_000.times do
       assert_equal "foo", msgs1.pop.routing_key
     end
-    assert ch2.wait_for_confirms
     connection.close
   end
 end


### PR DESCRIPTION
 make sure Channel#wait_for_confirms actually waits for all confirms

Previsouly the unbounded unconfirmed_empty queue could be filled up with
    thousands of items, until num_waiting was zero. Now we make the queue
    sized, so it can't hold more than 1 item. We now have a race condition
    on num_waiting instead...
