### PR TITLE
CI: Don't try to run RuboCop on Ruby 2.6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,4 +24,4 @@ require "yard"
 
 YARD::Rake::YardocTask.new
 
-task default: [:test, *(:rubocop if RUBY_ENGINE == "ruby")]
+task default: [:test, *(:rubocop if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.7.0")]


### PR DESCRIPTION
CI fails with

    Error: unrecognized cop or department plugins found in .rubocop.yml
    RuboCop failed!

It is because Ruby 2.6 is stuck on rubocop 1.50.2
https://github.com/cloudamqp/amqp-client.rb/actions/runs/17395071982/job/49375365037#step:5:74

and rubocop-minitest needs at least 1.75.0
https://github.com/rubocop/rubocop-minitest/blob/594b8dc87d02219f96d99d231ae19fd943823c38/rubocop-minitest.gemspec#L37

Ruby 2.7 is using rubocop 1.80.1
https://github.com/cloudamqp/amqp-client.rb/actions/runs/17395071982/job/49375365029#step:5:81