### PR TITLE
CI: Use TruffleRuby 24.2.2 in TLS tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         ruby:
           - "ruby" # latest stable release
           - "jruby"
-          - "truffleruby-23" # https://github.com/cloudamqp/amqp-client.rb/issues/16#issuecomment-2111624251
+          - "truffleruby"
     steps:
     - name: Install RabbitMQ
       run: sudo apt-get update && sudo apt-get install -y rabbitmq-server


### PR DESCRIPTION
This is the latest version currently.
https://github.com/oracle/truffleruby/releases/tag/graal-24.2.2

Close https://github.com/cloudamqp/amqp-client.rb/issues/16