### PR TITLE
Queue#subscribe handles ack and rejects for you

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ puts msg.body
 
 ### High level API
 
-The library provides a high-level API that is a bit easier to get started with, and also handles reconnection automatically.
+The library provides a high-level API that manages channels, content-types, encodings, reconnection automatically.
 
 ```ruby
 require "amqp-client"
@@ -69,6 +69,14 @@ myqueue.subscribe(prefetch: 20) do |msg|
   puts JSON.parse(msg.body)
 rescue => e
   puts e.full_message
+end
+# The message is automatically ack'd by Queue#subscribe if the block returns successfully
+# If the block raises the message is rejected and requeued.
+# You still can control the acking and rejecting in the block if you want to, e.g:
+myqueue.subscribe do |msg|
+  msg.ack
+rescue => e
+  msg.reject
 end
 
 # Publish directly to the queue

--- a/README.md
+++ b/README.md
@@ -67,10 +67,8 @@ myqueue.bind("amq.topic", "my.events.*")
 # between message arrival and when the message was supposed to be ack'ed.
 myqueue.subscribe(prefetch: 20) do |msg|
   puts JSON.parse(msg.body)
-  msg.ack
 rescue => e
   puts e.full_message
-  msg.reject(requeue: false)
 end
 
 # Publish directly to the queue

--- a/lib/amqp/client/message.rb
+++ b/lib/amqp/client/message.rb
@@ -14,6 +14,7 @@ module AMQP
         @redelivered = redelivered
         @properties = nil
         @body = ""
+        @ack_or_reject_sent = false
       end
 
       # The channel the message was deliviered to
@@ -52,14 +53,22 @@ module AMQP
       # Acknowledge the message
       # @return [nil]
       def ack
+        return if @ack_or_reject_sent
+
         @channel.basic_ack(@delivery_tag)
+        @ack_or_reject_sent = true
+        nil
       end
 
       # Reject the message
       # @param requeue [Boolean] If true the message will be put back into the queue again, ready to be redelivered
       # @return [nil]
       def reject(requeue: false)
+        return if @ack_or_reject_sent
+
         @channel.basic_reject(@delivery_tag, requeue:)
+        @ack_or_reject_sent = true
+        nil
       end
 
       # @see #exchange


### PR DESCRIPTION
Enhanced the `subscribe` method in `Queue` to automatically acknowledge messages after successful processing, and to reject (and optionally requeue) them if an exception is raised.

Messages track if they have already sent an ack/reject to be backwards compatible with code like

```ruby
q.subscribe |msg|
  msg.ack
end
```