### PR TITLE
Add convenience method for default exchange

### DIFF
--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -137,24 +137,32 @@ module AMQP
       end
     end
 
+    # Declare a direct exchange and return a high level Exchange object
+    # @param name [String] Name of the exchange (defaults to "amq.direct")
+    # @see {#exchange} for other parameters
+    # @return [Exchange]
+    def direct(name = "amq.direct", **)
+      return exchange(name, "direct", **) unless name.empty?
+
+      # Return the default exchange
+      @exchanges.fetch(name) do
+        @exchanges[name] = Exchange.new(self, name)
+      end
+    end
+
+    # Return a high level Exchange object for the default direct exchange
+    # @see {#direct} for parameters
+    # @return [Exchange]
+    def default(**)
+      direct("", **)
+    end
+
     # Declare a fanout exchange and return a high level Exchange object
     # @param name [String] Name of the exchange (defaults to "amq.fanout")
     # @see {#exchange} for other parameters
     # @return [Exchange]
     def fanout(name = "amq.fanout", **)
       exchange(name, "fanout", **)
-    end
-
-    # Declare a direct exchange and return a high level Exchange object
-    # @param name [String] Name of the exchange (defaults to "" for the default direct exchange)
-    # @see {#exchange} for other parameters
-    # @return [Exchange]
-    def direct(name = "", **)
-      return exchange(name, "direct", **) unless name.empty?
-
-      @exchanges.fetch(name) do
-        @exchanges[name] = Exchange.new(self, name)
-      end
     end
 
     # Declare a topic exchange and return a high level Exchange object

--- a/test/amqp/high_level_test.rb
+++ b/test/amqp/high_level_test.rb
@@ -146,10 +146,22 @@ class HighLevelTest < Minitest::Test
   def test_default_direct_exchange
     client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").start
     begin
-      direct = client.direct
+      direct = client.direct("amq.direct")
 
       assert_instance_of AMQP::Client::Exchange, direct
-      assert_equal "", direct.name
+      assert_equal "amq.direct", direct.name
+    ensure
+      client.stop
+    end
+  end
+
+  def test_default_exchange
+    client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").start
+    begin
+      default = client.default
+
+      assert_instance_of AMQP::Client::Exchange, default
+      assert_equal "", default.name
     ensure
       client.stop
     end


### PR DESCRIPTION
Breaking change for direct exchange defaute name. Its now amq.direct which make the api more consistent