### PR TITLE
API cleanup

### DIFF
--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -139,7 +139,7 @@ module AMQP
 
     # Declare a direct exchange and return a high level Exchange object
     # @param name [String] Name of the exchange (defaults to "amq.direct")
-    # @see {#exchange} for other parameters
+    # @see #exchange for other parameters
     # @return [Exchange]
     def direct_exchange(name = "amq.direct", **)
       return exchange(name, "direct", **) unless name.empty?
@@ -151,54 +151,54 @@ module AMQP
     end
 
     # @deprecated
-    # @see {#direct_exchange}
+    # @see #direct_exchange
     alias direct direct_exchange
 
     # Return a high level Exchange object for the default direct exchange
-    # @see {#direct} for parameters
+    # @see #direct for parameters
     # @return [Exchange]
     def default_exchange(**)
       direct("", **)
     end
 
     # @deprecated
-    # @see default_exchange
+    # @see #default_exchange
     alias default default_exchange
 
     # Declare a fanout exchange and return a high level Exchange object
     # @param name [String] Name of the exchange (defaults to "amq.fanout")
-    # @see {#exchange} for other parameters
+    # @see #exchange for other parameters
     # @return [Exchange]
     def fanout_exchange(name = "amq.fanout", **)
       exchange(name, "fanout", **)
     end
 
     # @deprecated
-    # @see {#fanout_exchange}
+    # @see #fanout_exchange
     alias fanout fanout_exchange
 
     # Declare a topic exchange and return a high level Exchange object
     # @param name [String] Name of the exchange (defaults to "amq.topic")
-    # @see {#exchange} for other parameters
+    # @see #exchange for other parameters
     # @return [Exchange]
     def topic_exchange(name = "amq.topic", **)
       exchange(name, "topic", **)
     end
 
     # @deprecated
-    # @see {#topic_exchange}
+    # @see #topic_exchange
     alias topic topic_exchange
 
     # Declare a headers exchange and return a high level Exchange object
     # @param name [String] Name of the exchange (defaults to "amq.headers")
-    # @see {#exchange} for other parameters
+    # @see #exchange for other parameters
     # @return [Exchange]
     def headers_exchange(name = "amq.headers", **)
       exchange(name, "headers", **)
     end
 
     # @deprecated
-    # @see {#headers_exchange}
+    # @see #headers_exchange
     alias headers headers_exchange
 
     # @!endgroup

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -141,7 +141,7 @@ module AMQP
     # @param name [String] Name of the exchange (defaults to "amq.direct")
     # @see {#exchange} for other parameters
     # @return [Exchange]
-    def direct(name = "amq.direct", **)
+    def direct_exchange(name = "amq.direct", **)
       return exchange(name, "direct", **) unless name.empty?
 
       # Return the default exchange
@@ -150,36 +150,56 @@ module AMQP
       end
     end
 
+    # @deprecated
+    # @see {#direct_exchange}
+    alias direct direct_exchange
+
     # Return a high level Exchange object for the default direct exchange
     # @see {#direct} for parameters
     # @return [Exchange]
-    def default(**)
+    def default_exchange(**)
       direct("", **)
     end
+
+    # @deprecated
+    # @see default_exchange
+    alias default default_exchange
 
     # Declare a fanout exchange and return a high level Exchange object
     # @param name [String] Name of the exchange (defaults to "amq.fanout")
     # @see {#exchange} for other parameters
     # @return [Exchange]
-    def fanout(name = "amq.fanout", **)
+    def fanout_exchange(name = "amq.fanout", **)
       exchange(name, "fanout", **)
     end
+
+    # @deprecated
+    # @see {#fanout_exchange}
+    alias fanout fanout_exchange
 
     # Declare a topic exchange and return a high level Exchange object
     # @param name [String] Name of the exchange (defaults to "amq.topic")
     # @see {#exchange} for other parameters
     # @return [Exchange]
-    def topic(name = "amq.topic", **)
+    def topic_exchange(name = "amq.topic", **)
       exchange(name, "topic", **)
     end
+
+    # @deprecated
+    # @see {#topic_exchange}
+    alias topic topic_exchange
 
     # Declare a headers exchange and return a high level Exchange object
     # @param name [String] Name of the exchange (defaults to "amq.headers")
     # @see {#exchange} for other parameters
     # @return [Exchange]
-    def headers(name = "amq.headers", **)
+    def headers_exchange(name = "amq.headers", **)
       exchange(name, "headers", **)
     end
+
+    # @deprecated
+    # @see {#headers_exchange}
+    alias headers headers_exchange
 
     # @!endgroup
     # @!group Publish

--- a/test/amqp/high_level_test.rb
+++ b/test/amqp/high_level_test.rb
@@ -146,7 +146,7 @@ class HighLevelTest < Minitest::Test
   def test_default_direct_exchange
     client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").start
     begin
-      direct = client.direct("amq.direct")
+      direct = client.direct_exchange("amq.direct")
 
       assert_instance_of AMQP::Client::Exchange, direct
       assert_equal "amq.direct", direct.name
@@ -158,7 +158,7 @@ class HighLevelTest < Minitest::Test
   def test_default_exchange
     client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").start
     begin
-      default = client.default
+      default = client.default_exchange
 
       assert_instance_of AMQP::Client::Exchange, default
       assert_equal "", default.name
@@ -170,7 +170,7 @@ class HighLevelTest < Minitest::Test
   def test_default_fanout_exchange
     client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").start
     begin
-      fanout = client.fanout
+      fanout = client.fanout_exchange
 
       assert_instance_of AMQP::Client::Exchange, fanout
       assert_equal "amq.fanout", fanout.name
@@ -182,7 +182,7 @@ class HighLevelTest < Minitest::Test
   def test_default_topic_exchange
     client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").start
     begin
-      topic = client.topic
+      topic = client.topic_exchange
 
       assert_instance_of AMQP::Client::Exchange, topic
       assert_equal "amq.topic", topic.name
@@ -194,7 +194,7 @@ class HighLevelTest < Minitest::Test
   def test_default_headers_exchange
     client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").start
     begin
-      headers = client.headers
+      headers = client.headers_exchange
 
       assert_instance_of AMQP::Client::Exchange, headers
       assert_equal "amq.headers", headers.name


### PR DESCRIPTION
Use more explicit method names for exchange creation, improving clarity and consistency. The old, shorter method names are now deprecated but still available as aliases to maintain backward compatibility. 
API refactoring for exchange creation: