### PR TITLE
Avoid shelling out to `git` when building the gem

### DIFF
--- a/amqp-client.gemspec
+++ b/amqp-client.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/cloudamqp/amqp-client.rb/blob/main/CHANGELOG.md"
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.files         = Dir["amqp-client.gemspec", "LICENSE.txt", "lib/**/*.rb"]
+  spec.files         = Dir["LICENSE.txt", "lib/**/*.rb"]
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
This is annoying when using the gem (the checked out source) with docker images that does not include git.

Before

```ruby
irb(main):001> `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
=>
[".github/workflows/codeql-analysis.yml",
 ".github/workflows/docs.yml",
 ".github/workflows/main.yml",
 ".github/workflows/release.yml",
 ".gitignore",
 ".rubocop.yml",
 ".rubocop_todo.yml",
 ".yardopts",
 "CHANGELOG.md",
 "CODEOWNERS",
 "Gemfile",
 "LICENSE.txt",
 "README.md",
 "Rakefile",
 "amqp-client.gemspec",
 "benchmarks/benchmark_stats.rb",
 "benchmarks/profile.rb",
 "benchmarks/throughput_benchmark.rb",
 "bin/console",
 "bin/setup",
 "lib/amqp-client.rb",
 "lib/amqp/client.rb",
 "lib/amqp/client/channel.rb",
 "lib/amqp/client/connection.rb",
 "lib/amqp/client/consumer.rb",
 "lib/amqp/client/errors.rb",
 "lib/amqp/client/exchange.rb",
 "lib/amqp/client/frame_bytes.rb",
 "lib/amqp/client/message.rb",
 "lib/amqp/client/properties.rb",
 "lib/amqp/client/queue.rb",
 "lib/amqp/client/rpc_client.rb",
 "lib/amqp/client/table.rb",
 "lib/amqp/client/version.rb"]
```

After

```ruby
irb(main):006> Dir['*', 'lib/**/*.rb']
=>
["CHANGELOG.md",
 "CODEOWNERS",
 "Gemfile",
 "Gemfile.lock",
 "LICENSE.txt",
 "README.md",
 "Rakefile",
 "amqp-client.gemspec",
 "benchmarks",
 "bin",
 "lib",
 "test",
 "lib/amqp/client/channel.rb",
 "lib/amqp/client/connection.rb",
 "lib/amqp/client/consumer.rb",
 "lib/amqp/client/errors.rb",
 "lib/amqp/client/exchange.rb",
 "lib/amqp/client/frame_bytes.rb",
 "lib/amqp/client/message.rb",
 "lib/amqp/client/properties.rb",
 "lib/amqp/client/queue.rb",
 "lib/amqp/client/rpc_client.rb",
 "lib/amqp/client/table.rb",
 "lib/amqp/client/version.rb",
 "lib/amqp/client.rb",
 "lib/amqp-client.rb"]
```