### PR TITLE
Per-consumer cancellation callbacks and lifecycle fixes

### DIFF
--- a/lib/amqp/client/connection.rb
+++ b/lib/amqp/client/connection.rb
@@ -340,7 +340,7 @@ module AMQP
               tag_len = buf.getbyte(4)
               tag = buf.byteslice(5, tag_len).force_encoding("utf-8")
               no_wait = buf.getbyte(5 + tag_len) == 1
-              channel.close_consumer(tag)
+              channel.cancel_consumer(tag)
               write_bytes FrameBytes.basic_cancel_ok(@id, tag) unless no_wait
             when 31 # cancel-ok
               tag_len = buf.getbyte(4)

--- a/lib/amqp/client/queue.rb
+++ b/lib/amqp/client/queue.rb
@@ -43,11 +43,13 @@ module AMQP
       #   0 means that the thread calling this method will be blocked
       # @param requeue_on_reject [Boolean] If true, messages that are rejected due to an exception in the block
       #   will be requeued. Only relevant if no_ack is false. (Default: true)
+      # @param on_cancel [Proc] Optional proc that will be called if the consumer is cancelled by the broker
+      #   The proc will be called with the consumer tag as the only argument
       # @param arguments [Hash] Custom arguments to the consumer
       # @yield [Message] Delivered message from the queue
       # @return [Consumer] The consumer object, which can be used to cancel the consumer
-      def subscribe(no_ack: false, prefetch: 1, worker_threads: 1, requeue_on_reject: true, arguments: {})
-        @client.subscribe(@name, no_ack:, prefetch:, worker_threads:, arguments:) do |message|
+      def subscribe(no_ack: false, prefetch: 1, worker_threads: 1, requeue_on_reject: true, on_cancel: nil, arguments: {})
+        @client.subscribe(@name, no_ack:, prefetch:, worker_threads:, on_cancel:, arguments:) do |message|
           yield message
           message.ack unless no_ack
         rescue StandardError => e


### PR DESCRIPTION
### Summary
This PR adds per-consumer `on_cancel` callbacks and fixes consumer lifecycle handling for server-initiated cancellations.

### Key Changes
- Introduce `on_cancel` proc parameter for `Client#subscribe`, `Queue#subscribe`, and `Channel#basic_consume`.
- Store callback alongside consumer metadata (`ConsumeOk` extended with `msg_q` and `on_cancel`).
- Ensure high-level wrapper removes consumer on server `basic.cancel` 
- Adjust `basic_cancel` flow to remove consumer only after broker confirmation (reduces race risk with in-flight deliveries).
- Tests added/updated: server basic.cancel handling (low-level and high-level), consumer removal on reconnect.

### Rationale
Server-initiated consumer cancellations (e.g. queue deletion, policy enforcement) were previously silent. Applications had no hook to resubscribe or record metrics. `on_cancel` exposes this event in a per-consumer manner.

### Implementation Notes
- High-level wrapper builds an internal `on_cancel_proc` that removes the consumer id then delegates to user callback.
- Channel stores a `Queue` per consumer in `ConsumeOk` for worker thread delivery; closing the queue cleanly terminates workers.
- Reconnect path reuses stored `consumer.on_cancel` so callbacks persist across reconnects.

### Testing
Targeted tests for cancellation events pass locally (see added/modified tests).