### PR TITLE
rpc improvements 2

### DIFF
--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -401,7 +401,7 @@ module AMQP
     # @!group RPC
 
     # Create a RPC server for a single method/function/procedure
-    # @param queue [String] name of the queue that RPC calls will be sent to
+    # @param method [String, Symbol] name of the RPC method to host (i.e. queue name on the server side)
     # @param worker_threads [Integer] number of threads that process requests
     # @param durable [Boolean] If true the queue will survive broker restarts
     # @param auto_delete [Boolean] If true the queue will be deleted when the last consumer stops consuming
@@ -411,31 +411,32 @@ module AMQP
     # @yieldparam [String] The body of the request message
     # @yieldreturn [String] The response message body
     # @return (see #subscribe)
-    def rpc_server(queue:, worker_threads: 1, durable: true, auto_delete: false, arguments: {}, &_)
-      queue(queue, durable:, auto_delete:, arguments:)
-      subscribe(queue, prefetch: worker_threads, worker_threads:) do |msg|
-        result = yield msg.body
-        msg.channel.basic_publish(result, exchange: "", routing_key: msg.properties.reply_to,
-                                          correlation_id: msg.properties.correlation_id)
-        msg.ack
-      rescue StandardError
-        msg.reject(requeue: false)
-        raise
-      end
+    def rpc_server(method, worker_threads: 1, durable: true, auto_delete: false, arguments: {}, &_)
+      queue(method.to_s, durable:, auto_delete:, arguments:)
+        .subscribe(prefetch: worker_threads, worker_threads:) do |msg|
+          result = yield msg.body
+          msg.channel.basic_publish(result, exchange: "", routing_key: msg.properties.reply_to,
+                                            correlation_id: msg.properties.correlation_id)
+          msg.ack
+        rescue StandardError
+          msg.reject(requeue: false)
+          raise
+        end
     end
 
     # Do a RPC call, sends a messages, waits for a response
+    # @param method [String, Symbol] name of the RPC method to call (i.e. queue name on the server side)
     # @param arguments [String] arguments/body to the call
-    # @param queue [String] name of the queue that RPC calls will be sent to
     # @param timeout [Numeric, nil] Number of seconds to wait for a response
+    # @option (see Client#publish)
     # @return [String] Returns the result from the call
     # @raise [Timeout::Error] if no response is received within the timeout period
-    def rpc_call(arguments, queue:, timeout: nil)
+    def rpc_call(method, arguments, timeout: nil, **properties)
       ch = with_connection(&:channel)
       begin
         msg = ch.basic_consume_once("amq.rabbitmq.reply-to", timeout:) do
-          ch.basic_publish(arguments, exchange: "", routing_key: queue,
-                                      reply_to: "amq.rabbitmq.reply-to")
+          ch.basic_publish(arguments, exchange: "", routing_key: method.to_s,
+                                      reply_to: "amq.rabbitmq.reply-to", **properties)
         end
         msg.body
       ensure

--- a/test/amqp/rpc_test.rb
+++ b/test/amqp/rpc_test.rb
@@ -50,4 +50,13 @@ class RPCTest < Minitest::Test
   ensure
     rpc_client.close
   end
+
+  def test_rpc_api_handles_message_coding
+    @client.rpc_server("rpc-test-method", auto_delete: true) do |request|
+      { response: "foo #{request[:key]}" }
+    end
+    result = @client.rpc_call("rpc-test-method", { key: "val" }, content_type: "application/json")
+
+    assert_equal({ response: "foo val" }, result)
+  end
 end

--- a/test/amqp/rpc_test.rb
+++ b/test/amqp/rpc_test.rb
@@ -14,38 +14,38 @@ class RPCTest < Minitest::Test
   end
 
   def test_that_rpc_server_responds_to_rpc_calls
-    @client.rpc_server(queue: "rpc-test-method", auto_delete: true) do |request|
+    @client.rpc_server("rpc-test-method", auto_delete: true) do |request|
       "foo #{request}"
     end
-    result = @client.rpc_call("bar", queue: "rpc-test-method")
+    result = @client.rpc_call("rpc-test-method", "bar")
 
     assert_equal "foo bar", result
   end
 
   def test_rpc_client_is_reusable
-    @client.rpc_server(queue: "rpc-test-method", auto_delete: true) do |request|
+    @client.rpc_server("rpc-test-method", auto_delete: true) do |request|
       "foo #{request}"
     end
 
     rpc_client = @client.rpc_client
-    result = rpc_client.call("bar", queue: "rpc-test-method")
+    result = rpc_client.call("rpc-test-method", "bar")
 
     assert_equal "foo bar", result
-    result = rpc_client.call("foo", queue: "rpc-test-method")
+    result = rpc_client.call("rpc-test-method", "foo")
 
     assert_equal "foo foo", result
   end
 
   def test_rpc_call_times_out
     assert_raises(Timeout::Error) do
-      @client.rpc_call("bar", queue: "rpc-test-method", timeout: 0.01)
+      @client.rpc_call("rpc-test-method", "bar", timeout: 0.01)
     end
   end
 
   def test_rpc_client_call_times_out
     rpc_client = @client.rpc_client
     assert_raises(Timeout::Error) do
-      rpc_client.call("bar", queue: "rpc-test-method", timeout: 0.01)
+      rpc_client.call("rpc-test-method", "bar", timeout: 0.01)
     end
   ensure
     rpc_client.close


### PR DESCRIPTION
- **Use RCP terminology, not amqp, in api**
  - Intentionally not using named arguments to make to api similar to Rubys `call` and `send` methods
- **Add automatic message coding to RPC api**
