### PR TITLE
Fix flaky teardown when connection is closed by broker (LavinMQ)

### DIFF
--- a/test/amqp/client_lifecycle_test.rb
+++ b/test/amqp/client_lifecycle_test.rb
@@ -13,6 +13,8 @@ class AMQPClientLifecycleTest < Minitest::Test
 
   def teardown
     @connection&.close
+  rescue AMQP::Client::Error::ConnectionClosed
+    nil
   end
 
   def test_it_can_connect


### PR DESCRIPTION
When running the tests against LavinMQ, at least `test_it_can_delete_exchange` occasionally fails in teardown with:

```
Error:
AMQPClientLifecycleTest#test_it_can_delete_exchange:
AMQP::Client::Error::ConnectionClosed: Connection closed (504) CHANNEL_ERROR - Channel 1 not open (60/70)
    lib/amqp/client/connection.rb:200:in 'AMQP::Client::Connection#write_bytes'
    lib/amqp/client/connection.rb:148:in 'AMQP::Client::Connection#close'
    test/amqp/client_lifecycle_test.rb:15:in 'AMQPClientLifecycleTest#teardown'
```

To reproduce, run against LavinMQ (reproduced with 2.6.10) repeatedly:

```
while bundle exec ruby -Ilib:test test/amqp/client_lifecycle_test.rb --name test_it_can_delete_exchange; do; done
```

It does not seem to happen for RabbitMQ. As a workaround, rescue in teardown so a broken connection doesn't cause spurious failures.