### PR TITLE
Close dedicated channel on Consumer#cancel

### DIFF
--- a/.github/workflows/lavinmq.yml
+++ b/.github/workflows/lavinmq.yml
@@ -107,7 +107,9 @@ jobs:
           - "ruby"
     steps:
     - name: Install LavinMQ
-      run: brew install lavinmq
+      run: |
+        brew update
+        brew install lavinmq
     - name: Start LavinMQ
       run: brew services start lavinmq
     - uses: actions/checkout@v6

--- a/.github/workflows/lavinmq.yml
+++ b/.github/workflows/lavinmq.yml
@@ -107,7 +107,7 @@ jobs:
           - "ruby"
     steps:
     - name: Install LavinMQ
-      run: brew install cloudamqp/cloudamqp/lavinmq
+      run: brew install lavinmq
     - name: Start LavinMQ
       run: brew services start lavinmq
     - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fixed: `Consumer#cancel` now closes the dedicated channel opened by `subscribe`, preventing a channel leak on long-lived connections that subscribe/cancel repeatedly (#81)
+
 ## [2.0.1] - 2025-11-18
 
 - Fixed: Ensure closing channels on basic get high level api (#73)

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -557,7 +557,12 @@ module AMQP
     def cancel_consumer(consumer)
       @consumers.delete(consumer.id)
       with_connection do |conn|
-        conn.channel(consumer.channel_id).basic_cancel(consumer.tag)
+        ch = conn.channel(consumer.channel_id)
+        begin
+          ch.basic_cancel(consumer.tag)
+        ensure
+          ch.close
+        end
       end
     end
 

--- a/test/amqp/high_level_test.rb
+++ b/test/amqp/high_level_test.rb
@@ -138,6 +138,24 @@ class HighLevelTest < Minitest::Test
     }, "Consumer was not removed after basic.cancel"
   end
 
+  def test_consumer_cancel_closes_dedicated_channel
+    q = @client.queue("test.cancel.leak")
+
+    20.times do
+      consumer = q.subscribe { |_msg| nil }
+      consumer.cancel
+    end
+
+    @client.with_connection do |conn|
+      open_channels = conn.instance_variable_get(:@channels).keys
+
+      # Only the shared channel 1 (used for queue declarations) should remain.
+      assert_equal [1], open_channels, "consumer.cancel leaked channels: #{open_channels.inspect}"
+    end
+  ensure
+    q&.delete
+  end
+
   def test_default_direct_exchange
     direct = @client.direct_exchange("amq.direct")
 


### PR DESCRIPTION
## Background

Fixes #81. Surfaced while fixing the same bug in [amqp-client.js #214](https://github.com/cloudamqp/amqp-client.js/pull/214).

`Client#subscribe` opens a fresh channel per subscription. Before this fix, `Consumer#cancel` → `Client#cancel_consumer` only sent `basic.cancel` and left the channel sitting in `Connection#@channels`. Long-lived processes that subscribe/cancel repeatedly (per-request SSE handlers, RPC patterns, anything that opens a temporary subscription) eventually hit `channel_max` and start failing.

Repro:

```ruby
client = AMQP::Client.new(\"amqp://localhost\").start
q = client.queue(\"leak-demo\")

100.times do
  consumer = q.subscribe { |msg| msg.ack }
  consumer.cancel
end
# Connection#@channels has ~100 stale entries
```

## Summary

- `Client#cancel_consumer` now closes the channel after `basic.cancel` via an `ensure` block, so the channel is released even if cancel raises.
- `Channel#close` is already idempotent (returns if `@closed` is set), so this is safe if the broker has already closed the channel.
- Added a regression test that subscribes/cancels 20 times and asserts only the shared channel 1 remains on the connection.

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/amqp/high_level_test.rb` passes (29 tests).
- [x] Verified the new test fails on `main` (`@channels.keys == [1..21]`) and passes with the fix (`[1]`).
- [x] Rubocop clean.