### PR TITLE
Name threads spawned by the client

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,7 +29,7 @@ Metrics/BlockNesting:
 # Offense count: 10
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 470
+  Max: 482
 
 # Offense count: 11
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,19 @@ msg = ch.basic_get(q.queue_name)
 puts msg.body
 ```
 
+### Thread naming
+
+The library spawns several threads (a read loop, optional heartbeat sender, consumer workers, a supervisor when using `Client#start`, ...). Each one gets a descriptive `Thread#name`, which shows up in `Thread.list`, stack dumps and most introspection tools.
+
+Pass `name:` to override the default prefix - useful when another library or app wraps `amqp-client.rb` and wants its threads to be easy to identify:
+
+```ruby
+AMQP::Client.new("amqp://localhost", name: "myapp").start
+# threads named "myapp.supervisor", "myapp.read_loop localhost:5672", etc.
+```
+
+The default prefix is `amqp` (kept short so e.g. `amqp.read_loop` still fits in the 15-char `/proc/<pid>/task/*/comm` field used by `ps -L` and `top -H`). Format is `"<prefix>.<role> <host>:<port>[ <detail>]"`. The full name is always visible via Ruby (`Thread.list.map(&:name)`, stack traces, debuggers); only the OS-level `comm` field is truncated.
+
 ## Supported Ruby versions
 
 All maintained Ruby versions are supported.

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ puts msg.body
 
 The library spawns several threads (a read loop, optional heartbeat sender, consumer workers, a supervisor when using `Client#start`, ...). Each one gets a descriptive `Thread#name`, which shows up in `Thread.list`, stack dumps and most introspection tools.
 
-Pass `name:` to override the default prefix - useful when another library or app wraps `amqp-client.rb` and wants its threads to be easy to identify:
+Pass `thread_name_prefix:` to override the default prefix - useful when another library or app wraps `amqp-client.rb` and wants its threads to be easy to identify:
 
 ```ruby
-AMQP::Client.new("amqp://localhost", name: "myapp").start
+AMQP::Client.new("amqp://localhost", thread_name_prefix: "myapp").start
 # threads named "myapp.supervisor", "myapp.read_loop localhost:5672", etc.
 ```
 

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -34,7 +34,7 @@ module AMQP
     #   Maximum allowed is 65_536.  The smallest of the client's and the broker's value will be used.
     def initialize(uri = "", **options)
       @uri = uri
-      @name = options.delete(:name) || "amqp"
+      @thread_name_prefix = options.delete(:thread_name_prefix) || "amqp"
       @options = options
       @queues = {}
       @exchanges = {}
@@ -58,13 +58,13 @@ module AMQP
     # @example
     #   connection = AMQP::Client.new("amqps://server.rmq.cloudamqp.com", connection_name: "My connection").connect
     def connect(read_loop_thread: true)
-      Connection.new(@uri, read_loop_thread:, name: @name,
+      Connection.new(@uri, read_loop_thread:, thread_name_prefix: @thread_name_prefix,
                            codec_registry: @codec_registry, strict_coding: @strict_coding, **@options)
     end
 
-    # Thread name prefix used for threads spawned by this client.
+    # Prefix used for naming threads spawned by this client.
     # @return [String]
-    attr_reader :name
+    attr_reader :thread_name_prefix
 
     # Opens an AMQP connection using the high level API, will try to reconnect if successfully connected at first
     # @return [self]
@@ -103,7 +103,7 @@ module AMQP
               # Remove consumers whose internal queues were already closed (e.g. cancelled during reconnect window)
               @consumers.delete_if { |_, c| c.closed? }
             end
-            setup.name = "#{@name}.reconnect_setup"
+            setup.name = "#{@thread_name_prefix}.reconnect_setup"
             conn.read_loop # blocks until connection is closed, then reconnect
           rescue Error => e
             warn "AMQP-Client reconnect error: #{e.inspect}"
@@ -113,7 +113,7 @@ module AMQP
             conn = nil
           end
         end
-        supervisor.name = "#{@name}.supervisor"
+        supervisor.name = "#{@thread_name_prefix}.supervisor"
       end
       self
     end

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -34,6 +34,7 @@ module AMQP
     #   Maximum allowed is 65_536.  The smallest of the client's and the broker's value will be used.
     def initialize(uri = "", **options)
       @uri = uri
+      @name = options.delete(:name) || "amqp"
       @options = options
       @queues = {}
       @exchanges = {}
@@ -57,8 +58,13 @@ module AMQP
     # @example
     #   connection = AMQP::Client.new("amqps://server.rmq.cloudamqp.com", connection_name: "My connection").connect
     def connect(read_loop_thread: true)
-      Connection.new(@uri, read_loop_thread:, codec_registry: @codec_registry, strict_coding: @strict_coding, **@options)
+      Connection.new(@uri, read_loop_thread:, name: @name,
+                           codec_registry: @codec_registry, strict_coding: @strict_coding, **@options)
     end
+
+    # Thread name prefix used for threads spawned by this client.
+    # @return [String]
+    attr_reader :name
 
     # Opens an AMQP connection using the high level API, will try to reconnect if successfully connected at first
     # @return [self]
@@ -74,14 +80,14 @@ module AMQP
 
         @supervisor_started = true
         @stopped = false
-        Thread.new(connect(read_loop_thread: false)) do |conn|
+        supervisor = Thread.new(connect(read_loop_thread: false)) do |conn| # rubocop:disable Metrics/BlockLength
           Thread.current.abort_on_exception = true # Raising an unhandled exception is a bug
           loop do
             break if @stopped
 
             conn ||= connect(read_loop_thread: false)
 
-            Thread.new do
+            setup = Thread.new do
               # restore connection in another thread, read_loop have to run
               conn.channel(1) # reserve channel 1 for publishes
               @consumers.each_value do |consumer|
@@ -97,6 +103,7 @@ module AMQP
               # Remove consumers whose internal queues were already closed (e.g. cancelled during reconnect window)
               @consumers.delete_if { |_, c| c.closed? }
             end
+            setup.name = "#{@name}.reconnect_setup"
             conn.read_loop # blocks until connection is closed, then reconnect
           rescue Error => e
             warn "AMQP-Client reconnect error: #{e.inspect}"
@@ -106,6 +113,7 @@ module AMQP
             conn = nil
           end
         end
+        supervisor.name = "#{@name}.supervisor"
       end
       self
     end

--- a/lib/amqp/client/channel.rb
+++ b/lib/amqp/client/channel.rb
@@ -348,8 +348,10 @@ module AMQP
             consume_loop(msg_q, consumer_tag, &blk)
             nil
           else
-            threads = Array.new(worker_threads) do
-              Thread.new { consume_loop(msg_q, consumer_tag, &blk) }
+            threads = Array.new(worker_threads) do |i|
+              t = Thread.new { consume_loop(msg_q, consumer_tag, &blk) }
+              t.name = @connection.thread_name("consumer", "ch=#{@id} tag=#{consumer_tag} ##{i + 1}")
+              t
             end
             @consumers[consumer_tag] =
               ConsumeOk.new(channel_id: @id, consumer_tag:, worker_threads: threads, msg_q:, on_cancel:)
@@ -589,7 +591,8 @@ module AMQP
           next_msg = @next_msg
           if next_msg.is_a? ReturnMessage
             if @on_return
-              Thread.new { @on_return.call(next_msg) }
+              t = Thread.new { @on_return.call(next_msg) }
+              t.name = @connection.thread_name("on_return", "ch=#{@id}")
             else
               warn "AMQP-Client message returned: #{next_msg.inspect}"
             end

--- a/lib/amqp/client/channel.rb
+++ b/lib/amqp/client/channel.rb
@@ -350,7 +350,7 @@ module AMQP
           else
             threads = Array.new(worker_threads) do |i|
               t = Thread.new { consume_loop(msg_q, consumer_tag, &blk) }
-              t.name = @connection.thread_name("consumer", "ch=#{@id} tag=#{consumer_tag} ##{i + 1}")
+              t.name = @connection.thread_name(role: "consumer", detail: "ch=#{@id} tag=#{consumer_tag} ##{i + 1}")
               t
             end
             @consumers[consumer_tag] =
@@ -592,7 +592,7 @@ module AMQP
           if next_msg.is_a? ReturnMessage
             if @on_return
               t = Thread.new { @on_return.call(next_msg) }
-              t.name = @connection.thread_name("on_return", "ch=#{@id}")
+              t.name = @connection.thread_name(role: "on_return", detail: "ch=#{@id}")
             else
               warn "AMQP-Client message returned: #{next_msg.inspect}"
             end

--- a/lib/amqp/client/connection.rb
+++ b/lib/amqp/client/connection.rb
@@ -70,7 +70,7 @@ module AMQP
         return unless read_loop_thread
 
         t = Thread.new { read_loop }
-        t.name = thread_name("read_loop")
+        t.name = thread_name(role: "read_loop")
       end
 
       # Prefix used for naming threads spawned by this connection.
@@ -80,7 +80,7 @@ module AMQP
       # Build a thread name for a role attached to this connection.
       # Format: "<prefix>.<role> <host>:<port>[ <detail>]"
       # @api private
-      def thread_name(role, detail = nil)
+      def thread_name(role:, detail: nil)
         base = "#{@thread_name_prefix}.#{role} #{@host}:#{@port}"
         detail ? "#{base} #{detail}" : base
       end
@@ -494,7 +494,7 @@ module AMQP
             end
           end
         end
-        t.name = thread_name("heartbeat")
+        t.name = thread_name(role: "heartbeat")
       end
 
       def send_heartbeat

--- a/lib/amqp/client/connection.rb
+++ b/lib/amqp/client/connection.rb
@@ -15,6 +15,9 @@ module AMQP
       # @param uri [String] URL on the format amqp://username:password@hostname/vhost, use amqps:// for encrypted connection
       # @param read_loop_thread [Boolean] If true run {#read_loop} in a background thread,
       #   otherwise the user have to run it explicitly, without {#read_loop} the connection won't function
+      # @param name [String] Prefix used when naming threads spawned by this connection
+      #   (read_loop, heartbeat, consumers, ...). Wrapper libraries can pass their own prefix
+      #   to make their threads easy to identify in introspection tools.
       # @param codec_registry [MessageCodecRegistry] Registry for message codecs
       # @param strict_coding [Boolean] Whether to raise errors on unsupported codecs
       # @option options [Boolean] connection_name (PROGRAM_NAME) Set a name for the connection to be able to identify
@@ -28,7 +31,8 @@ module AMQP
       #   Maxium allowed is 65_536.  The smallest of the client's and the broker's value will be used.
       # @option options [String] keepalive (60:10:3) TCP keepalive setting, 60s idle, 10s interval between probes, 3 probes
       # @return [Connection]
-      def initialize(uri = "", read_loop_thread: true, codec_registry: nil, strict_coding: false, **options)
+      def initialize(uri = "", read_loop_thread: true, name: "amqp",
+                     codec_registry: nil, strict_coding: false, **options)
         uri = URI.parse(uri)
         tls = uri.scheme == "amqps"
         port = port_from_env || uri.port || (tls ? 5671 : 5672)
@@ -37,6 +41,10 @@ module AMQP
         password = uri.password || "guest"
         vhost = URI.decode_www_form_component(uri.path[1..] || "/")
         options = URI.decode_www_form(uri.query || "").map! { |k, v| [k.to_sym, v] }.to_h.merge(options)
+
+        @name = name
+        @host = host
+        @port = port
 
         socket = open_socket(host, port, tls, options)
         channel_max, frame_max, heartbeat = establish(socket, user, password, vhost, options)
@@ -59,7 +67,22 @@ module AMQP
         # Only used with heartbeats
         @last_activity_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-        Thread.new { read_loop } if read_loop_thread
+        return unless read_loop_thread
+
+        t = Thread.new { read_loop }
+        t.name = thread_name("read_loop")
+      end
+
+      # Thread name prefix used for threads spawned by this connection.
+      # @return [String]
+      attr_reader :name
+
+      # Build a thread name for a role attached to this connection.
+      # Format: "<prefix>.<role> <host>:<port>[ <detail>]"
+      # @api private
+      def thread_name(role, detail = nil)
+        base = "#{@name}.#{role} #{@host}:#{@port}"
+        detail ? "#{base} #{detail}" : base
       end
 
       # Indicates that the server is blocking publishes.
@@ -451,7 +474,7 @@ module AMQP
 
       # Start the heartbeat background thread (called from connection#tune)
       def start_heartbeats(period)
-        Thread.new do
+        t = Thread.new do
           Thread.current.abort_on_exception = true # Raising an unhandled exception is a bug
           interval = period / 2.0
           loop do
@@ -471,6 +494,7 @@ module AMQP
             end
           end
         end
+        t.name = thread_name("heartbeat")
       end
 
       def send_heartbeat

--- a/lib/amqp/client/connection.rb
+++ b/lib/amqp/client/connection.rb
@@ -15,7 +15,7 @@ module AMQP
       # @param uri [String] URL on the format amqp://username:password@hostname/vhost, use amqps:// for encrypted connection
       # @param read_loop_thread [Boolean] If true run {#read_loop} in a background thread,
       #   otherwise the user have to run it explicitly, without {#read_loop} the connection won't function
-      # @param name [String] Prefix used when naming threads spawned by this connection
+      # @param thread_name_prefix [String] Prefix used when naming threads spawned by this connection
       #   (read_loop, heartbeat, consumers, ...). Wrapper libraries can pass their own prefix
       #   to make their threads easy to identify in introspection tools.
       # @param codec_registry [MessageCodecRegistry] Registry for message codecs
@@ -31,7 +31,7 @@ module AMQP
       #   Maxium allowed is 65_536.  The smallest of the client's and the broker's value will be used.
       # @option options [String] keepalive (60:10:3) TCP keepalive setting, 60s idle, 10s interval between probes, 3 probes
       # @return [Connection]
-      def initialize(uri = "", read_loop_thread: true, name: "amqp",
+      def initialize(uri = "", read_loop_thread: true, thread_name_prefix: "amqp",
                      codec_registry: nil, strict_coding: false, **options)
         uri = URI.parse(uri)
         tls = uri.scheme == "amqps"
@@ -42,7 +42,7 @@ module AMQP
         vhost = URI.decode_www_form_component(uri.path[1..] || "/")
         options = URI.decode_www_form(uri.query || "").map! { |k, v| [k.to_sym, v] }.to_h.merge(options)
 
-        @name = name
+        @thread_name_prefix = thread_name_prefix
         @host = host
         @port = port
 
@@ -73,15 +73,15 @@ module AMQP
         t.name = thread_name("read_loop")
       end
 
-      # Thread name prefix used for threads spawned by this connection.
+      # Prefix used for naming threads spawned by this connection.
       # @return [String]
-      attr_reader :name
+      attr_reader :thread_name_prefix
 
       # Build a thread name for a role attached to this connection.
       # Format: "<prefix>.<role> <host>:<port>[ <detail>]"
       # @api private
       def thread_name(role, detail = nil)
-        base = "#{@name}.#{role} #{@host}:#{@port}"
+        base = "#{@thread_name_prefix}.#{role} #{@host}:#{@port}"
         detail ? "#{base} #{detail}" : base
       end
 

--- a/test/amqp/thread_names_test.rb
+++ b/test/amqp/thread_names_test.rb
@@ -14,7 +14,7 @@ class AMQPThreadNamesTest < Minitest::Test
   end
 
   def test_custom_prefix_flows_through
-    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", name: "myapp").connect
+    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", thread_name_prefix: "myapp").connect
     names = Thread.list.map(&:name)
 
     assert(names.any? { |n| n&.start_with?("myapp.read_loop ") },

--- a/test/amqp/thread_names_test.rb
+++ b/test/amqp/thread_names_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class AMQPThreadNamesTest < Minitest::Test
+  def test_default_read_loop_thread_name
+    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").connect
+    names = Thread.list.map(&:name)
+
+    assert(names.any? { |n| n&.start_with?("amqp.read_loop ") },
+           "Expected a thread named 'amqp.read_loop ...', got: #{names.inspect}")
+  ensure
+    connection&.close
+  end
+
+  def test_custom_prefix_flows_through
+    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", name: "myapp").connect
+    names = Thread.list.map(&:name)
+
+    assert(names.any? { |n| n&.start_with?("myapp.read_loop ") },
+           "Expected a thread named 'myapp.read_loop ...', got: #{names.inspect}")
+  ensure
+    connection&.close
+  end
+
+  def test_heartbeat_thread_name
+    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", heartbeat: 1).connect
+    names = Thread.list.map(&:name)
+
+    assert(names.any? { |n| n&.start_with?("amqp.heartbeat ") },
+           "Expected a thread named 'amqp.heartbeat ...', got: #{names.inspect}")
+  ensure
+    connection&.close
+  end
+
+  def test_consumer_worker_thread_names_include_channel_and_index
+    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").connect
+    ch = connection.channel
+    q = ch.queue_declare("", exclusive: true)
+    ch.basic_consume(q.queue_name, worker_threads: 2, &:ack)
+
+    matching = Thread.list.map(&:name).select { |n| n&.start_with?("amqp.consumer ") }
+    suffixes = matching.map { |n| n[/ch=\d+ tag=\S+ #\d+\z/] }
+
+    assert_equal 2, suffixes.compact.size, "Expected 2 named consumer worker threads, got: #{matching.inspect}"
+  ensure
+    connection&.close
+  end
+end


### PR DESCRIPTION
Set a descriptive Thread#name on every thread the library spawns (read_loop, heartbeat, consumer workers, on_return, supervisor, reconnect_setup) so they show up clearly in Thread.list and other introspection tools.

Add a `name:` option on Client and Connection (default "amqp") so wrapper libraries can supply their own prefix. The default is kept short so "amqp.read_loop" (14 chars) fits in the 15-char comm field used by `ps -L` / `top -H`.

Format: `<prefix>.<role> <host>:<port>[ <detail>]`