### PR TITLE
Log connect/reconnect/disconnect via configurable logger

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,7 +29,7 @@ Metrics/BlockNesting:
 # Offense count: 10
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 470
+  Max: 482
 
 # Offense count: 11
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
 - Fixed: `Consumer#cancel` now closes the dedicated channel opened by `subscribe`, preventing a channel leak on long-lived connections that subscribe/cancel repeatedly (#81)
+- Added: `logger:` option on `AMQP::Client.new` that emits info/warn lifecycle messages for connect, reconnect, and disconnect in the supervised `#start` loop. The prefix uses `?name=` from the URL when present.
+- Added: Every thread the library spawns (read_loop, heartbeat, consumer workers, on_return, supervisor, reconnect_setup) now gets a descriptive `Thread#name`. When the URL includes `?name=`, that identifier is embedded in each thread's name too, matching the lifecycle log prefix.
 
 ## [2.0.1] - 2025-11-18
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Pass `?name=` in the connection URL to identify a client instance. The same iden
 ```ruby
 require "logger"
 
-client = AMQP::Client.new("amqp://broker/?name=worker-1", logger: Logger.new($stdout))
+client = AMQP::Client.new("amqp://broker?name=worker-1", logger: Logger.new($stdout))
 client.start
 # => INFO -- : AMQP::Client[worker-1]: connected
 # Thread.list now includes:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,26 @@ client = AMQP::Client.new("amqp://localhost")
 client.default_content_type = "text/plain"  # Override for this instance
 ```
 
+#### Lifecycle logging and thread names
+
+Pass `?name=` in the connection URL to identify a client instance. The same identifier appears in both lifecycle log lines and `Thread#name` for every thread the library spawns:
+
+```ruby
+require "logger"
+
+client = AMQP::Client.new("amqp://broker/?name=worker-1", logger: Logger.new($stdout))
+client.start
+# => INFO -- : AMQP::Client[worker-1]: connected
+# Thread.list now includes:
+#   "amqp.supervisor[worker-1]"
+#   "amqp.read_loop[worker-1] broker:5672"
+#   "amqp.heartbeat[worker-1] broker:5672"  (when heartbeat > 0)
+```
+
+Without `?name=`, threads use the shorter form (`amqp.read_loop broker:5672`) and the log prefix is plain `AMQP::Client:`. The `amqp` segment is kept short so `amqp.read_loop` (14 chars) still fits the 15-char `comm` field used by `ps -L` and `top -H`.
+
+When `logger:` is not set, reconnect errors still go to stderr via `Kernel#warn` so existing behavior is preserved.
+
 ### Low level API
 
 This API matches the AMQP protocol very well, it can do everything the protocol allows, but requires some knowledge about the protocol, and doesn't handle reconnects.

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -62,7 +62,8 @@ module AMQP
     # @example
     #   connection = AMQP::Client.new("amqps://server.rmq.cloudamqp.com", connection_name: "My connection").connect
     def connect(read_loop_thread: true)
-      Connection.new(@uri, read_loop_thread:, codec_registry: @codec_registry, strict_coding: @strict_coding, **@options)
+      Connection.new(@uri, read_loop_thread:, name: @name,
+                           codec_registry: @codec_registry, strict_coding: @strict_coding, **@options)
     end
 
     # Opens an AMQP connection using the high level API, will try to reconnect if successfully connected at first
@@ -81,7 +82,7 @@ module AMQP
         @stopped = false
         initial_conn = connect(read_loop_thread: false)
         log_lifecycle(:info, "connected")
-        Thread.new(initial_conn) do |conn| # rubocop:disable Metrics/BlockLength
+        supervisor = Thread.new(initial_conn) do |conn| # rubocop:disable Metrics/BlockLength
           Thread.current.abort_on_exception = true # Raising an unhandled exception is a bug
           loop do # rubocop:disable Metrics/BlockLength
             break if @stopped
@@ -91,7 +92,7 @@ module AMQP
               log_lifecycle(:info, "reconnected")
             end
 
-            Thread.new do
+            setup = Thread.new do
               # restore connection in another thread, read_loop have to run
               conn.channel(1) # reserve channel 1 for publishes
               @consumers.each_value do |consumer|
@@ -107,6 +108,7 @@ module AMQP
               # Remove consumers whose internal queues were already closed (e.g. cancelled during reconnect window)
               @consumers.delete_if { |_, c| c.closed? }
             end
+            setup.name = thread_name("reconnect_setup")
             conn.read_loop # blocks until connection is closed, then reconnect
             log_lifecycle(:warn, "disconnected")
           rescue Error => e
@@ -117,6 +119,7 @@ module AMQP
             conn = nil
           end
         end
+        supervisor.name = thread_name("supervisor")
       end
       self
     end
@@ -603,6 +606,10 @@ module AMQP
       else
         warn "AMQP-Client reconnect error: #{err.inspect}"
       end
+    end
+
+    def thread_name(role)
+      @name ? "amqp.#{role}[#{@name}]" : "amqp.#{role}"
     end
 
     def lifecycle_prefix

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -32,9 +32,14 @@ module AMQP
     #    the smallest of the client's and the broker's values will be used
     # @option options [Integer] channel_max (2048) Maximum number of channels the client will be allowed to have open.
     #   Maximum allowed is 65_536.  The smallest of the client's and the broker's value will be used.
+    # @option options [#info, #warn, #error] logger (nil) Logger for {#start} lifecycle events
+    #   (connected/reconnected/disconnected/reconnect errors). When nil, reconnect errors are
+    #   written to stderr via Kernel#warn for backwards compatibility.
     def initialize(uri = "", **options)
       @uri = uri
       @options = options
+      @logger = options[:logger]
+      @name = parse_name(uri)
       @queues = {}
       @exchanges = {}
       @consumers = {}
@@ -74,12 +79,17 @@ module AMQP
 
         @supervisor_started = true
         @stopped = false
-        Thread.new(connect(read_loop_thread: false)) do |conn|
+        initial_conn = connect(read_loop_thread: false)
+        log_lifecycle(:info, "connected")
+        Thread.new(initial_conn) do |conn| # rubocop:disable Metrics/BlockLength
           Thread.current.abort_on_exception = true # Raising an unhandled exception is a bug
-          loop do
+          loop do # rubocop:disable Metrics/BlockLength
             break if @stopped
 
-            conn ||= connect(read_loop_thread: false)
+            unless conn
+              conn = connect(read_loop_thread: false)
+              log_lifecycle(:info, "reconnected")
+            end
 
             Thread.new do
               # restore connection in another thread, read_loop have to run
@@ -98,8 +108,9 @@ module AMQP
               @consumers.delete_if { |_, c| c.closed? }
             end
             conn.read_loop # blocks until connection is closed, then reconnect
+            log_lifecycle(:warn, "disconnected")
           rescue Error => e
-            warn "AMQP-Client reconnect error: #{e.inspect}"
+            log_reconnect_error(e)
             sleep @options[:reconnect_interval] || 1
           ensure
             @connq.clear
@@ -567,6 +578,36 @@ module AMQP
     end
 
     private
+
+    def parse_name(uri)
+      return nil if uri.nil? || uri.empty?
+
+      query = URI.parse(uri).query
+      return nil unless query
+
+      URI.decode_www_form(query).each { |k, v| return v if k == "name" }
+      nil
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def log_lifecycle(level, event)
+      return unless @logger
+
+      @logger.public_send(level, "#{lifecycle_prefix}: #{event}")
+    end
+
+    def log_reconnect_error(err)
+      if @logger
+        @logger.warn("#{lifecycle_prefix}: reconnect error: #{err.inspect}")
+      else
+        warn "AMQP-Client reconnect error: #{err.inspect}"
+      end
+    end
+
+    def lifecycle_prefix
+      @name ? "AMQP::Client[#{@name}]" : "AMQP::Client"
+    end
 
     def default_content_properties
       {

--- a/lib/amqp/client/channel.rb
+++ b/lib/amqp/client/channel.rb
@@ -348,8 +348,10 @@ module AMQP
             consume_loop(msg_q, consumer_tag, &blk)
             nil
           else
-            threads = Array.new(worker_threads) do
-              Thread.new { consume_loop(msg_q, consumer_tag, &blk) }
+            threads = Array.new(worker_threads) do |i|
+              t = Thread.new { consume_loop(msg_q, consumer_tag, &blk) }
+              t.name = @connection.thread_name(role: "consumer", detail: "ch=#{@id} tag=#{consumer_tag} ##{i + 1}")
+              t
             end
             @consumers[consumer_tag] =
               ConsumeOk.new(channel_id: @id, consumer_tag:, worker_threads: threads, msg_q:, on_cancel:)
@@ -589,7 +591,8 @@ module AMQP
           next_msg = @next_msg
           if next_msg.is_a? ReturnMessage
             if @on_return
-              Thread.new { @on_return.call(next_msg) }
+              t = Thread.new { @on_return.call(next_msg) }
+              t.name = @connection.thread_name(role: "on_return", detail: "ch=#{@id}")
             else
               warn "AMQP-Client message returned: #{next_msg.inspect}"
             end

--- a/lib/amqp/client/connection.rb
+++ b/lib/amqp/client/connection.rb
@@ -17,6 +17,9 @@ module AMQP
       #   otherwise the user have to run it explicitly, without {#read_loop} the connection won't function
       # @param codec_registry [MessageCodecRegistry] Registry for message codecs
       # @param strict_coding [Boolean] Whether to raise errors on unsupported codecs
+      # @param name [String, nil] Instance identifier embedded in thread names
+      #   (e.g. "amqp.read_loop[name] host:port") and lifecycle log prefixes.
+      #   Usually sourced from the URL's `?name=` query param by {Client}.
       # @option options [Boolean] connection_name (PROGRAM_NAME) Set a name for the connection to be able to identify
       #   the client from the broker
       # @option options [Boolean] verify_peer (true) Verify broker's TLS certificate, set to false for self-signed certs
@@ -28,7 +31,7 @@ module AMQP
       #   Maxium allowed is 65_536.  The smallest of the client's and the broker's value will be used.
       # @option options [String] keepalive (60:10:3) TCP keepalive setting, 60s idle, 10s interval between probes, 3 probes
       # @return [Connection]
-      def initialize(uri = "", read_loop_thread: true, codec_registry: nil, strict_coding: false, **options)
+      def initialize(uri = "", read_loop_thread: true, codec_registry: nil, strict_coding: false, name: nil, **options)
         uri = URI.parse(uri)
         tls = uri.scheme == "amqps"
         port = port_from_env || uri.port || (tls ? 5671 : 5672)
@@ -37,6 +40,10 @@ module AMQP
         password = uri.password || "guest"
         vhost = URI.decode_www_form_component(uri.path[1..] || "/")
         options = URI.decode_www_form(uri.query || "").map! { |k, v| [k.to_sym, v] }.to_h.merge(options)
+
+        @host = host
+        @port = port
+        @name = name
 
         socket = open_socket(host, port, tls, options)
         channel_max, frame_max, heartbeat = establish(socket, user, password, vhost, options)
@@ -59,7 +66,20 @@ module AMQP
         # Only used with heartbeats
         @last_activity_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-        Thread.new { read_loop } if read_loop_thread
+        return unless read_loop_thread
+
+        t = Thread.new { read_loop }
+        t.name = thread_name(role: "read_loop")
+      end
+
+      # Build a thread name for a role attached to this connection.
+      # Format: "amqp.<role>[<name>] <host>:<port>[ <detail>]" — the `[<name>]`
+      # segment is only present when the connection has a `name:`.
+      # @api private
+      def thread_name(role:, detail: nil)
+        suffix = @name ? "[#{@name}]" : ""
+        base = "amqp.#{role}#{suffix} #{@host}:#{@port}"
+        detail ? "#{base} #{detail}" : base
       end
 
       # Indicates that the server is blocking publishes.
@@ -451,7 +471,7 @@ module AMQP
 
       # Start the heartbeat background thread (called from connection#tune)
       def start_heartbeats(period)
-        Thread.new do
+        t = Thread.new do
           Thread.current.abort_on_exception = true # Raising an unhandled exception is a bug
           interval = period / 2.0
           loop do
@@ -471,6 +491,7 @@ module AMQP
             end
           end
         end
+        t.name = thread_name(role: "heartbeat")
       end
 
       def send_heartbeat

--- a/test/amqp/client_test.rb
+++ b/test/amqp/client_test.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
+require "logger"
+require "stringio"
 
 # Specs that does not use connection setup/teardown (see client_lifecycle_test.rb)
 class AMQPClientLifecycleTest < Minitest::Test
+  def wait_for_log(io, pattern, timeout: 2) # rubocop:disable Naming/PredicateMethod
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    until Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+      return true if io.string.match?(pattern)
+
+      sleep 0.01
+    end
+    false
+  end
+
   def test_that_it_has_a_version_number
     refute_nil ::AMQP::Client::VERSION
   end
@@ -61,5 +73,31 @@ class AMQPClientLifecycleTest < Minitest::Test
     end
   ensure
     connection&.close
+  end
+
+  def test_logger_emits_connected_and_disconnected_on_start_stop
+    io = StringIO.new
+    logger = Logger.new(io)
+    logger.formatter = ->(severity, _time, _progname, msg) { "#{severity} #{msg}\n" }
+
+    client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", logger:).start
+    client.with_connection { _1 } # wait until supervisor's read_loop is engaged
+    client.stop
+
+    assert wait_for_log(io, /^INFO AMQP::Client: connected$/), "missing connected log: #{io.string.inspect}"
+    assert wait_for_log(io, /^WARN AMQP::Client: disconnected$/), "missing disconnected log: #{io.string.inspect}"
+  end
+
+  def test_logger_prefix_includes_name_from_uri
+    io = StringIO.new
+    logger = Logger.new(io)
+    logger.formatter = ->(severity, _time, _progname, msg) { "#{severity} #{msg}\n" }
+
+    client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}/?name=my-worker", logger:).start
+    client.with_connection { _1 }
+    client.stop
+
+    assert wait_for_log(io, /AMQP::Client\[my-worker\]: connected/),
+           "missing named connect log: #{io.string.inspect}"
   end
 end

--- a/test/amqp/client_test.rb
+++ b/test/amqp/client_test.rb
@@ -93,7 +93,7 @@ class AMQPClientLifecycleTest < Minitest::Test
     logger = Logger.new(io)
     logger.formatter = ->(severity, _time, _progname, msg) { "#{severity} #{msg}\n" }
 
-    client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}/?name=my-worker", logger:).start
+    client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}?name=my-worker", logger:).start
     client.with_connection { _1 }
     client.stop
 

--- a/test/amqp/thread_names_test.rb
+++ b/test/amqp/thread_names_test.rb
@@ -14,7 +14,7 @@ class AMQPThreadNamesTest < Minitest::Test
   end
 
   def test_name_from_uri_appears_in_read_loop_thread_name
-    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}/?name=worker-1").connect
+    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}?name=worker-1").connect
     names = Thread.list.map(&:name)
 
     assert(names.any? { |n| n&.start_with?("amqp.read_loop[worker-1] ") },
@@ -48,7 +48,7 @@ class AMQPThreadNamesTest < Minitest::Test
   end
 
   def test_supervisor_thread_name_when_named
-    client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}/?name=worker-2").start
+    client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}?name=worker-2").start
     client.with_connection { _1 } # wait until supervisor's read_loop is engaged
     names = Thread.list.map(&:name)
 

--- a/test/amqp/thread_names_test.rb
+++ b/test/amqp/thread_names_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class AMQPThreadNamesTest < Minitest::Test
+  def test_default_read_loop_thread_name
+    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").connect
+    names = Thread.list.map(&:name)
+
+    assert(names.any? { |n| n&.start_with?("amqp.read_loop ") },
+           "Expected a thread named 'amqp.read_loop ...', got: #{names.inspect}")
+  ensure
+    connection&.close
+  end
+
+  def test_name_from_uri_appears_in_read_loop_thread_name
+    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}/?name=worker-1").connect
+    names = Thread.list.map(&:name)
+
+    assert(names.any? { |n| n&.start_with?("amqp.read_loop[worker-1] ") },
+           "Expected a thread named 'amqp.read_loop[worker-1] ...', got: #{names.inspect}")
+  ensure
+    connection&.close
+  end
+
+  def test_heartbeat_thread_name
+    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", heartbeat: 1).connect
+    names = Thread.list.map(&:name)
+
+    assert(names.any? { |n| n&.start_with?("amqp.heartbeat ") },
+           "Expected a thread named 'amqp.heartbeat ...', got: #{names.inspect}")
+  ensure
+    connection&.close
+  end
+
+  def test_consumer_worker_thread_names_include_channel_and_index
+    connection = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").connect
+    ch = connection.channel
+    q = ch.queue_declare("", exclusive: true)
+    ch.basic_consume(q.queue_name, worker_threads: 2, &:ack)
+
+    matching = Thread.list.map(&:name).select { |n| n&.start_with?("amqp.consumer ") }
+    suffixes = matching.map { |n| n[/ch=\d+ tag=\S+ #\d+\z/] }
+
+    assert_equal 2, suffixes.compact.size, "Expected 2 named consumer worker threads, got: #{matching.inspect}"
+  ensure
+    connection&.close
+  end
+
+  def test_supervisor_thread_name_when_named
+    client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}/?name=worker-2").start
+    client.with_connection { _1 } # wait until supervisor's read_loop is engaged
+    names = Thread.list.map(&:name)
+
+    assert_includes names, "amqp.supervisor[worker-2]"
+  ensure
+    client&.stop
+  end
+end


### PR DESCRIPTION
## Background

`AMQP::Client#start` supervises a reconnecting connection, but the only output today is a `Kernel#warn` to stderr when a reconnect attempt fails. Successful connects, reconnects, and disconnects are silent — downstream users either roll their own callbacks or fly blind. Once we're touching the supervisor loop for logging, the threads it spawns deserve names too (subsumes #84).

Closes #85. Companion to the JS sibling cloudamqp/amqp-client.js#219.

## Summary

Two changes, one identity source (`?name=` in the URL drives both).

### Lifecycle logging

- New `logger:` option on `AMQP::Client.new`. Any object that responds to `info`/`warn`/`error` works (stdlib `Logger`, semantic_logger, custom wrapper).
- When set, the supervised reconnect loop emits:
  - `info AMQP::Client[name]: connected` after the initial connect
  - `info AMQP::Client[name]: reconnected` after each subsequent reconnect
  - `warn AMQP::Client[name]: disconnected` whenever `read_loop` returns
  - `warn AMQP::Client[name]: reconnect error: #{e.inspect}` on transient reconnect failures
- When `logger:` is unset, reconnect errors still go to stderr via `Kernel#warn` so existing behavior is preserved.

### Thread naming (intent of #84, unified)

- Every spawned thread (read_loop, heartbeat, consumer workers, on_return, supervisor, reconnect_setup) gets a descriptive `Thread#name`.
- When the URL has `?name=worker-1`, the identifier is embedded in each thread name the same way it appears in log prefixes:
  ```
  Thread.list  -> "amqp.read_loop[worker-1] broker:5672"
  log line     -> "AMQP::Client[worker-1]: connected"
  ```
- Without `?name=`, names degrade gracefully (`amqp.read_loop broker:5672`).
- The `amqp` segment is fixed (not a user-configurable prefix) so `amqp.read_loop` stays inside the 15-char `comm` field used by `ps -L` and `top -H`. The earlier `thread_name_prefix:` kwarg proposed in #84 isn't carried over — the URL `?name=` is the single source of identity.

```ruby
require "logger"
client = AMQP::Client.new("amqp://broker/?name=worker-1", logger: Logger.new($stdout))
client.start
# => INFO -- : AMQP::Client[worker-1]: connected
# Thread.list now contains "amqp.supervisor[worker-1]",
#   "amqp.read_loop[worker-1] broker:5672", etc.
```

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/amqp/client_test.rb` — lifecycle logger assertions pass
- [x] `bundle exec ruby -Ilib -Itest test/amqp/thread_names_test.rb` — all 5 thread-naming assertions pass
- [x] `bundle exec rake test` — full suite green except the pre-existing `test_it_can_update_secret` failure (unrelated, broker doesn't support update-secret in this config)
- [x] `bundle exec rubocop` — clean