### PR TITLE
Add Coders::DeflateRaw for RFC 1951 raw DEFLATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,15 @@ end
 **Built-in codecs** support these formats:
 - `application/json` - JSON encoding/decoding
 - `gzip` - Gzip compression
-- `deflate` - Deflate compression
+- `deflate` - Deflate compression (RFC 1950, zlib-wrapped)
+
+The `AMQP::Client::Coders::DeflateRaw` coder is shipped but not registered by default. It produces raw DEFLATE (RFC 1951, no zlib header or Adler-32 checksum), matching what Node's `zlib.deflateRaw` emits. Opt in by registering it under whichever content_encoding you want, e.g.:
+
+```ruby
+AMQP::Client.configure do |config|
+  config.register_coder(content_encoding: "deflate", coder: AMQP::Client::Coders::DeflateRaw)
+end
+```
 
 These settings will be used as defaults for all client instances, but can be overridden per-instance:
 

--- a/lib/amqp/client/message_codecs.rb
+++ b/lib/amqp/client/message_codecs.rb
@@ -39,10 +39,18 @@ module AMQP
         def decode(data, _properties) = Zlib.inflate(data)
       end.new
 
-      # Raw DEFLATE (RFC 1951): no zlib header, no Adler-32 checksum.
-      # Use when peers send Content-Encoding: deflate the HTTP-ambiguous way
-      # (e.g. Node's zlib.deflateRaw). Not registered by default; opt in by
-      # registering it under the desired content_encoding.
+      # Raw DEFLATE coder (RFC 1951 -- no zlib header, no Adler-32 checksum).
+      # Not registered by default. Use to interoperate with producers that emit
+      # raw DEFLATE under content_encoding "deflate", the same ambiguity HTTP
+      # has carried for decades and that Zlib::Deflate.new(level, -MAX_WBITS)
+      # exists for.
+      #
+      # @example Override the built-in deflate coder
+      #   AMQP::Client.configure do |config|
+      #     config.enable_builtin_codecs
+      #     config.register_coder(content_encoding: "deflate",
+      #                           coder: AMQP::Client::Coders::DeflateRaw)
+      #   end
       DeflateRaw = Class.new do
         def encode(data, _properties)
           return data if data.encoding == Encoding::BINARY

--- a/lib/amqp/client/message_codecs.rb
+++ b/lib/amqp/client/message_codecs.rb
@@ -38,6 +38,32 @@ module AMQP
 
         def decode(data, _properties) = Zlib.inflate(data)
       end.new
+
+      # Raw DEFLATE (RFC 1951): no zlib header, no Adler-32 checksum.
+      # Use when peers send Content-Encoding: deflate the HTTP-ambiguous way
+      # (e.g. Node's zlib.deflateRaw). Not registered by default; opt in by
+      # registering it under the desired content_encoding.
+      DeflateRaw = Class.new do
+        def encode(data, _properties)
+          return data if data.encoding == Encoding::BINARY
+
+          deflater = Zlib::Deflate.new(Zlib::DEFAULT_COMPRESSION, -Zlib::MAX_WBITS)
+          begin
+            deflater.deflate(data, Zlib::FINISH)
+          ensure
+            deflater.close
+          end
+        end
+
+        def decode(data, _properties)
+          inflater = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+          begin
+            inflater.inflate(data)
+          ensure
+            inflater.close
+          end
+        end
+      end.new
     end
   end
 end

--- a/test/amqp/high_level_encoding_test.rb
+++ b/test/amqp/high_level_encoding_test.rb
@@ -61,25 +61,35 @@ class HighLevelEncodingTest < Minitest::Test
     assert_equal "deflate me", inflated
   end
 
-  def test_deflate_raw_round_trip
+  def test_deflate_raw_round_trips_when_registered_as_deflate_override
     client = DummyClient.new
     client.codec_registry.enable_builtin_codecs
-    client.codec_registry.register_coder(content_encoding: "deflate-raw",
+    client.codec_registry.register_coder(content_encoding: "deflate",
                                          coder: AMQP::Client::Coders::DeflateRaw)
     exchange = AMQP::Client::Exchange.new(client, "ex1")
 
-    exchange.publish("raw deflate", routing_key: "rk", content_encoding: "deflate-raw")
+    exchange.publish("raw deflate test", routing_key: "rk", content_encoding: "deflate")
     published = client.published.last
-    inflated = Zlib::Inflate.new(-Zlib::MAX_WBITS).inflate(published[:body])
+    inflated = AMQP::Client::Coders::DeflateRaw.decode(published[:body], nil)
 
-    assert_equal "raw deflate", inflated
-    refute_equal Zlib.deflate("raw deflate"), published[:body]
+    assert_equal "raw deflate test", inflated
   end
 
-  def test_deflate_raw_decode_matches_zlib_deflate_raw_input
-    raw = Zlib::Deflate.new(Zlib::DEFAULT_COMPRESSION, -Zlib::MAX_WBITS).deflate("hello", Zlib::FINISH)
+  def test_deflate_raw_output_is_not_zlib_wrapped
+    # RFC 1950 (zlib-wrapped) output begins with 0x78. Raw DEFLATE doesn't.
+    wrapped = AMQP::Client::Coders::Deflate.encode("hello", nil)
+    raw = AMQP::Client::Coders::DeflateRaw.encode("hello", nil)
 
-    assert_equal "hello", AMQP::Client::Coders::DeflateRaw.decode(raw, nil)
+    assert_equal 0x78, wrapped.bytes.first
+    refute_equal 0x78, raw.bytes.first
+  end
+
+  def test_deflate_raw_output_is_not_decodable_by_deflate_coder
+    raw = AMQP::Client::Coders::DeflateRaw.encode("hello", nil)
+
+    assert_raises(Zlib::DataError) do
+      AMQP::Client::Coders::Deflate.decode(raw, nil)
+    end
   end
 
   def test_handles_already_deflated_body

--- a/test/amqp/high_level_encoding_test.rb
+++ b/test/amqp/high_level_encoding_test.rb
@@ -61,6 +61,27 @@ class HighLevelEncodingTest < Minitest::Test
     assert_equal "deflate me", inflated
   end
 
+  def test_deflate_raw_round_trip
+    client = DummyClient.new
+    client.codec_registry.enable_builtin_codecs
+    client.codec_registry.register_coder(content_encoding: "deflate-raw",
+                                         coder: AMQP::Client::Coders::DeflateRaw)
+    exchange = AMQP::Client::Exchange.new(client, "ex1")
+
+    exchange.publish("raw deflate", routing_key: "rk", content_encoding: "deflate-raw")
+    published = client.published.last
+    inflated = Zlib::Inflate.new(-Zlib::MAX_WBITS).inflate(published[:body])
+
+    assert_equal "raw deflate", inflated
+    refute_equal Zlib.deflate("raw deflate"), published[:body]
+  end
+
+  def test_deflate_raw_decode_matches_zlib_deflate_raw_input
+    raw = Zlib::Deflate.new(Zlib::DEFAULT_COMPRESSION, -Zlib::MAX_WBITS).deflate("hello", Zlib::FINISH)
+
+    assert_equal "hello", AMQP::Client::Coders::DeflateRaw.decode(raw, nil)
+  end
+
   def test_handles_already_deflated_body
     message = "deflate me"
     body = Zlib::Deflate.deflate(message)


### PR DESCRIPTION
## Background

The built-in `deflate` coder uses [`Zlib.deflate`](https://docs.ruby-lang.org/en/master/Zlib.html#method-c-deflate), which produces [RFC 1950](https://www.rfc-editor.org/rfc/rfc1950): zlib-wrapped DEFLATE (2-byte zlib header + raw DEFLATE + Adler-32 checksum). [HTTP/1.1 (RFC 9110 §8.4.1.2)](https://www.rfc-editor.org/rfc/rfc9110#section-8.4.1.2) agrees:

> The "deflate" coding is a "zlib" data format [RFC1950] containing a "deflate" compressed data stream [RFC1951] that uses a combination of the Lempel-Ziv (LZ77) compression algorithm and Huffman coding.

That's the standard, that's what the default ships.

In practice, plenty of producers labelling messages with `content_encoding: deflate` emit [RFC 1951](https://www.rfc-editor.org/rfc/rfc1951) raw DEFLATE — no header, no checksum. The HTTP spec even acknowledges the ambiguity directly in a note immediately after the definition above:

> *Note:* Some non-conformant implementations send the "deflate" compressed data without the zlib wrapper.

Same reason Ruby exposes raw DEFLATE via [`Zlib::Deflate.new(level, -Zlib::MAX_WBITS)`](https://docs.ruby-lang.org/en/master/Zlib/Deflate.html#method-c-new) (analog of Node's [`zlib.deflateRawSync`](https://nodejs.org/api/zlib.html#zlibdeflaterawsyncbuffer-options)).

This library is public, so the default follows the spec. Consumers that need to interop with raw-emitting producers (we have some internally — console-stream's feedback flow) can opt in.

## Summary

- New `AMQP::Client::Coders::DeflateRaw` constant backed by `Zlib::Deflate.new(level, -Zlib::MAX_WBITS)` / `Zlib::Inflate.new(-Zlib::MAX_WBITS)`. Not registered by default.
- Users opt in by overriding the default `deflate` mapping, or by registering under a separate key like `deflate-raw` for stricter apps:
  ```ruby
  AMQP::Client.configure do |config|
    config.enable_builtin_codecs
    config.register_coder(content_encoding: "deflate",
                          coder: AMQP::Client::Coders::DeflateRaw)
  end
  ```
- Default `deflate` behavior stays RFC 1950 — spec-correct, doesn't surprise users coming from HTTP semantics.

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/amqp/high_level_encoding_test.rb` — 18 tests pass
- [x] `bundle exec rubocop lib/amqp/client/message_codecs.rb test/amqp/high_level_encoding_test.rb` clean
- [x] New tests cover: round-trip via override, byte-level distinction from zlib-wrapped (no `0x78` magic byte), and that raw output is not decodable by the zlib-wrapped coder

Closes #87. Mirrors cloudamqp/amqp-client.js#223.