### PR TITLE
Add consumer_tag: kwarg to Client#subscribe and Queue#subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Added: `consumer_tag:` keyword argument on `Client#subscribe` and `Queue#subscribe` for setting a custom consumer tag. Defaults to broker-assigned.
 - Fixed: `Consumer#cancel` now closes the dedicated channel opened by `subscribe`, preventing a channel leak on long-lived connections that subscribe/cancel repeatedly (#81)
 
 ## [2.0.1] - 2025-11-18

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -302,10 +302,11 @@ module AMQP
     # @param on_cancel [Proc] Optional proc that will be called if the consumer is cancelled by the broker
     #   The proc will be called with the consumer tag as the only argument
     # @param arguments [Hash] Custom arguments to the consumer
+    # @param consumer_tag [String, nil] Custom consumer tag. When nil the broker auto-assigns one (default: nil)
     # @yield [Message] Delivered message from the queue
     # @return [Consumer] The consumer object, which can be used to cancel the consumer
     def subscribe(queue, exclusive: false, no_ack: false, prefetch: 1, worker_threads: 1,
-                  on_cancel: nil, arguments: {}, &blk)
+                  on_cancel: nil, arguments: {}, consumer_tag: nil, &blk)
       raise ArgumentError, "worker_threads have to be > 0" if worker_threads <= 0
 
       with_connection do |conn|
@@ -316,7 +317,8 @@ module AMQP
           @consumers.delete(consumer_id)
           on_cancel&.call(tag)
         end
-        basic_consume_args = { exclusive:, no_ack:, worker_threads:, on_cancel: on_cancel_proc, arguments: }
+        basic_consume_args = { tag: consumer_tag || "", exclusive:, no_ack:, worker_threads:,
+                               on_cancel: on_cancel_proc, arguments: }
         consume_ok = ch.basic_consume(queue, **basic_consume_args, &blk)
         consumer = Consumer.new(client: self, channel_id: ch.id, id: consumer_id, block: blk,
                                 queue:, consume_ok:, prefetch:, basic_consume_args:)

--- a/lib/amqp/client/queue.rb
+++ b/lib/amqp/client/queue.rb
@@ -50,11 +50,13 @@ module AMQP
       # @param on_cancel [Proc] Optional proc that will be called if the consumer is cancelled by the broker
       #   The proc will be called with the consumer tag as the only argument
       # @param arguments [Hash] Custom arguments to the consumer
+      # @param consumer_tag [String, nil] Custom consumer tag. When nil the broker auto-assigns one (default: nil)
       # @yield [Message] Delivered message from the queue
       # @return [Consumer] The consumer object, which can be used to cancel the consumer
       def subscribe(no_ack: false, exclusive: false, prefetch: 1, worker_threads: 1, requeue_on_reject: true,
-                    on_cancel: nil, arguments: {})
-        @client.subscribe(@name, no_ack:, exclusive:, prefetch:, worker_threads:, on_cancel:, arguments:) do |message|
+                    on_cancel: nil, arguments: {}, consumer_tag: nil)
+        @client.subscribe(@name, no_ack:, exclusive:, prefetch:, worker_threads:,
+                                 on_cancel:, arguments:, consumer_tag:) do |message|
           yield message
           message.ack unless no_ack
         rescue StandardError => e

--- a/test/amqp/high_level_test.rb
+++ b/test/amqp/high_level_test.rb
@@ -457,6 +457,24 @@ class HighLevelTest < Minitest::Test
     consumer.cancel
   end
 
+  def test_subscribe_with_explicit_consumer_tag
+    q = @client.queue("test.consumer.tag", auto_delete: true)
+    msgs = Queue.new
+
+    consumer = q.subscribe(no_ack: true, consumer_tag: "my-named-consumer") do |msg|
+      msgs.push msg
+    end
+
+    assert_equal "my-named-consumer", consumer.tag
+
+    q.publish("hi")
+    msg = msgs.pop
+
+    assert_equal "my-named-consumer", msg.delivery_info.consumer_tag
+  ensure
+    consumer&.cancel
+  end
+
   def test_passive_queue_raises_if_not_exists
     # Try to declare a queue with passive: true when it doesn't exist
     # Should raise an error because the queue doesn't exist


### PR DESCRIPTION
Ability to set a custom consumer tag via the higher level subscribe methods, prevously only available in `Channel#basic_consume`.

Empty string (default) preserves existing behaviour: broker auto-assigns the tag.

The tag flows through basic_consume_args, which the supervisor replays on reconnect, so custom tags survive reconnection.