### PR TITLE
Fix lost-wakeup hang in `Channel#wait_for_confirms`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Fixed: `Channel#wait_for_confirms` no longer hangs when the broker closes the channel (e.g. a publish to a missing exchange) right before the publishing thread starts waiting. The closed-channel check now runs before the condition-variable wait, so the wakeup from `#closed!` can't be lost. This resolves a flaky `ChannelClosed`-expected timeout that surfaced on truffleruby, whose threads run truly in parallel.
 - Fixed: `Consumer#cancel` now closes the dedicated channel opened by `subscribe`, preventing a channel leak on long-lived connections that subscribe/cancel repeatedly (#81)
 - Added: `logger:` option on `AMQP::Client.new` that emits info/warn lifecycle messages for connect, reconnect, and disconnect in the supervised `#start` loop. The prefix uses `?name=` from the URL when present.
 - Added: Every thread the library spawns (read_loop, heartbeat, consumer workers, on_return, supervisor, reconnect_setup) now gets a descriptive `Thread#name`. When the URL includes `?name=`, that identifier is embedded in each thread's name too, matching the lifecycle log prefix.

--- a/lib/amqp/client/channel.rb
+++ b/lib/amqp/client/channel.rb
@@ -469,8 +469,12 @@ module AMQP
         def wait_for_confirms
           @unconfirmed_lock.synchronize do
             until @unconfirmed.empty?
-              @unconfirmed_empty.wait(@unconfirmed_lock)
+              # Check before waiting: if the channel was closed (and the
+              # @unconfirmed_empty broadcast from #closed! fired) before we got
+              # here, the wakeup is already gone and #wait would block forever.
               raise Error::Closed.new(@id, *@closed) if @closed
+
+              @unconfirmed_empty.wait(@unconfirmed_lock)
             end
             result = !@nacked
             @nacked = false # Reset for next round of publishes

--- a/test/amqp/channel_test.rb
+++ b/test/amqp/channel_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+# Unit tests for Connection::Channel that drive its threading contract
+# directly, without a live broker.
+class ChannelTest < Minitest::Test
+  # Minimal Connection double. #wait_for_confirms, #closed!, #confirm_select
+  # and #basic_publish only ever call #frame_max and #write_bytes on their
+  # connection, so a no-op writer is enough to exercise them.
+  class FakeConnection
+    def frame_max = 131_072
+    def write_bytes(*); end
+  end
+
+  # Regression test for a lost-wakeup race in #wait_for_confirms.
+  #
+  # When the broker closes the channel (e.g. a publish to a missing exchange)
+  # the read_loop thread runs #closed!, which broadcasts @unconfirmed_empty.
+  # If that broadcast lands *before* the publishing thread starts waiting on
+  # the condition variable, the wakeup is lost: @unconfirmed is never emptied,
+  # so #wait_for_confirms would block forever. It must instead notice the
+  # closed channel and raise.
+  #
+  # Running #closed! before #wait_for_confirms reproduces the losing
+  # interleaving deterministically (no broker, no sleeps). Before the fix this
+  # deadlocked (caught here by Timeout); after it, ChannelClosed is raised at
+  # once. This race surfaces on truffleruby, whose threads run truly in
+  # parallel, far more often than on MRI.
+  def test_wait_for_confirms_raises_when_channel_closed_before_waiting
+    channel = AMQP::Client::Connection::Channel.new(FakeConnection.new, 1)
+    channel.confirm_select(no_wait: true)
+    channel.basic_publish("msg", exchange: "missing", routing_key: "rk")
+
+    # Simulate the read_loop handling the broker's channel.close frame: this
+    # sets @closed and broadcasts to @unconfirmed_empty with nobody waiting.
+    channel.closed!(:channel, 404, "NOT_FOUND - no exchange 'missing'", 60, 40)
+
+    assert_raises(AMQP::Client::Error::ChannelClosed) do
+      Timeout.timeout(5, Timeout::Error, "wait_for_confirms blocked: lost wakeup not handled") do
+        channel.wait_for_confirms
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the broker closes the channel (e.g. publishing to a missing exchange), the read_loop thread runs `#closed!`, which broadcasts `@unconfirmed_empty`. The closed-channel guard ran *after* `ConditionVariable#wait`, so if that broadcast landed before the publishing thread parked, the wakeup was lost and `#wait_for_confirms` blocked forever.

Check `@closed` *before* waiting so a broadcast can't be missed.

MRI's GVL almost always lets the publisher park first; truffleruby's true parallelism loses the race often, surfacing as a flaky `ChannelClosed`-expected timeout in CI. Adds a deterministic, broker-free regression test that reproduces the losing interleaving.

[Recently I saw this test](https://github.com/dentarg/amqp-client.rb/actions/runs/27010450408/job/79712465356#step:6:16) timeout on truffleruby, which makes me believe this is the correct fix.

https://github.com/cloudamqp/amqp-client.rb/blob/71672dedf10a27f28d88fa43174b6cd884648015/test/amqp/high_level_test.rb#L71-L76