### PR TITLE
Fix NameError from mistyped frame-end error constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Fixed: A malformed frame end during the connection handshake (e.g. connecting to a non-AMQP service) now raises the intended `Error::UnexpectedFrameEnd` instead of a `NameError` from a mistyped constant, which previously surfaced as a confusing `invalid handshake (uninitialized constant AMQP::Client::Error::UnexpectedFrameTypeEnd)` message
 - Fixed: `Channel#wait_for_confirms` no longer hangs when the broker closes the channel (e.g. a publish to a missing exchange) right before the publishing thread starts waiting. The closed-channel check now runs before the condition-variable wait, so the wakeup from `#closed!` can't be lost. This resolves a flaky `ChannelClosed`-expected timeout that surfaced on truffleruby, whose threads run truly in parallel.
 - Fixed: `Consumer#cancel` now closes the dedicated channel opened by `subscribe`, preventing a channel leak on long-lived connections that subscribe/cancel repeatedly (#81)
 - Added: `logger:` option on `AMQP::Client.new` that emits info/warn lifecycle messages for connect, reconnect, and disconnect in the supervised `#start` loop. The prefix uses `?name=` from the URL when present.

--- a/lib/amqp/client/connection.rb
+++ b/lib/amqp/client/connection.rb
@@ -243,7 +243,7 @@ module AMQP
 
           # make sure that the frame end is correct
           frame_end = socket.readchar.ord
-          raise Error::UnexpectedFrameTypeEnd, frame_end if frame_end != 206
+          raise Error::UnexpectedFrameEnd, frame_end if frame_end != 206
 
           # parse the frame, will return false if a close frame was received
           parse_frame(type, channel_id, frame_buffer) || return
@@ -553,7 +553,7 @@ module AMQP
 
           type, channel_id, frame_size = buf.unpack("C S> L>")
           frame_end = buf.getbyte(frame_size + 7)
-          raise Error::UnexpectedFrameTypeEnd, frame_end if frame_end != 206
+          raise Error::UnexpectedFrameEnd, frame_end if frame_end != 206
 
           case type
           when 1 # method frame

--- a/test/amqp/client_test.rb
+++ b/test/amqp/client_test.rb
@@ -23,9 +23,11 @@ class AMQPClientLifecycleTest < Minitest::Test
   def test_it_raises_on_connecting_to_unrelated_service
     with_fake_server do |port|
       client = AMQP::Client.new("amqp://guest1:guest2@#{TEST_AMQP_HOST}:#{port}")
-      assert_raises(AMQP::Client::Error) do
+      error = assert_raises(AMQP::Client::Error) do
         client.connect
       end
+      # The unexpected frame end must surface as the intended error
+      assert_instance_of AMQP::Client::Error::UnexpectedFrameEnd, error.cause
     end
   end
 

--- a/test/amqp/client_test.rb
+++ b/test/amqp/client_test.rb
@@ -26,7 +26,6 @@ class AMQPClientLifecycleTest < Minitest::Test
       error = assert_raises(AMQP::Client::Error) do
         client.connect
       end
-      # The unexpected frame end must surface as the intended error
       assert_instance_of AMQP::Client::Error::UnexpectedFrameEnd, error.cause
     end
   end


### PR DESCRIPTION
The connection read loop and handshake referenced
`Error::UnexpectedFrameTypeEnd`, which is never defined (errors.rb has `UnexpectedFrameType` and `UnexpectedFrameEnd`; the two were conflated). A malformed frame end (e.g. connecting to a non-AMQP service) therefore raised a `NameError` that the handshake's `rescue Exception` re-wrapped as the confusing "invalid handshake (uninitialized constant AMQP::Client::Error::UnexpectedFrameTypeEnd)".

Use the intended `Error::UnexpectedFrameEnd` at both sites so the error reads "Expected frame end 206 but got ...". Strengthen the existing unrelated-service test to assert the cause is `UnexpectedFrameEnd` (it caught a `NameError` before the fix).