### PR TITLE
Buffer full frame header during handshake (fixes JRuby short read)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,7 +29,7 @@ Metrics/BlockNesting:
 # Offense count: 10
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 483
+  Max: 484
 
 # Offense count: 11
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Fixed: A malformed frame end during the connection handshake (e.g. connecting to a non-AMQP service) now raises the intended `Error::UnexpectedFrameEnd` instead of a `NameError` from a mistyped constant, which previously surfaced as a confusing `invalid handshake (uninitialized constant AMQP::Client::Error::UnexpectedFrameTypeEnd)` message
+- Fixed: The handshake now buffers the full 7-byte frame header before parsing it. On JRuby the header could arrive split across reads, leaving `frame_size` nil and raising `NoMethodError` ("undefined method '+' for nil") instead of `UnexpectedFrameEnd` when connecting to a non-AMQP service
 - Fixed: `Channel#wait_for_confirms` no longer hangs when the broker closes the channel (e.g. a publish to a missing exchange) right before the publishing thread starts waiting. The closed-channel check now runs before the condition-variable wait, so the wakeup from `#closed!` can't be lost. This resolves a flaky `ChannelClosed`-expected timeout that surfaced on truffleruby, whose threads run truly in parallel.
 - Fixed: When the read loop exits on an abrupt socket close (no channel/connection close frame from the broker), open channels are now marked closed, so callers blocked in `#wait_for_confirms` or awaiting a broker reply raise `ConnectionClosed` instead of hanging forever.
 - Fixed: `Consumer#cancel` now closes the dedicated channel opened by `subscribe`, preventing a channel leak on long-lived connections that subscribe/cancel repeatedly (#81)

--- a/lib/amqp/client/connection.rb
+++ b/lib/amqp/client/connection.rb
@@ -551,6 +551,9 @@ module AMQP
         loop do # rubocop:disable Metrics/BlockLength
           begin
             socket.readpartial(4096, buf)
+            # The 7-byte frame header may arrive split across reads (seen on JRuby); buffer it
+            # fully before unpacking, else frame_size is nil and frame_end below fails on nil.
+            buf << socket.readpartial(4096) while buf.bytesize < 7
           rescue *READ_EXCEPTIONS => e
             raise Error, "Could not establish AMQP connection: #{e.message}"
           end

--- a/test/amqp/client_test.rb
+++ b/test/amqp/client_test.rb
@@ -30,6 +30,16 @@ class AMQPClientLifecycleTest < Minitest::Test
     end
   end
 
+  def test_it_raises_unexpected_frame_end_when_frame_header_arrives_split
+    socket = ChunkedSocket.new("foo", "bar\n") # 7-byte non-AMQP header, split in two
+    Socket.stub(:tcp, socket) do
+      error = assert_raises(AMQP::Client::Error) do
+        AMQP::Client.new("amqp://#{TEST_AMQP_HOST}").connect
+      end
+      assert_instance_of AMQP::Client::Error::UnexpectedFrameEnd, error.cause
+    end
+  end
+
   def test_it_raises_on_bad_credentials
     client = AMQP::Client.new("amqp://guest1:guest2@#{TEST_AMQP_HOST}")
     assert_raises(AMQP::Client::Error) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,6 +84,25 @@ module ThreadHelpers
   end
 end
 
+# Socket stand-in that hands out preset byte chunks across successive reads,
+# so tests can drive the handshake parser deterministically (no real network,
+# no timing). Used to reproduce frame headers that arrive split across reads.
+class ChunkedSocket
+  def initialize(*chunks)
+    @chunks = chunks
+  end
+
+  def setsockopt(*); end
+  def write(*); end
+  def close; end
+
+  def readpartial(_maxlen, outbuf = +"")
+    raise EOFError, "end of file reached" if @chunks.empty?
+
+    outbuf.replace(@chunks.shift)
+  end
+end
+
 $VERBOSE = nil unless ENV["DEBUG"] == "true"
 
 Minitest::Test.prepend TimeoutEveryTestCase


### PR DESCRIPTION
`establish` assumed a single `readpartial` returned at least the 7-byte frame header. On JRuby the header can arrive split across reads, so `buf.unpack("C S> L>")` returned a nil `frame_size` and `buf.getbyte(frame_size + 7)` raised `NoMethodError: undefined method '+' for nil` instead of `UnexpectedFrameEnd` when connecting to a non-AMQP service. This surfaced as a CI failure on the jruby build, where the unrelated-service spec asserts `error.cause` is `UnexpectedFrameEnd`.

Buffer the full header before unpacking. The common case (whole frame in the first read) is unchanged — the extra read only runs on a short read.

Add a deterministic regression spec: a `ChunkedSocket` test double hands out the 7-byte header in two chunks (no timing/sleeps), reproducing the split read on every platform. Without the fix it fails with the exact CI error; with it, `error.cause` is `UnexpectedFrameEnd`.