### PR TITLE
Fix release-notes extraction under mawk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
           # Extract changelog section for this version with better handling
           if grep -q "## \[$VERSION\]" CHANGELOG.md; then
-            awk "/^## \[$VERSION\]/ {flag=1; next} /^## \[/ && flag {exit} flag && /\S/ {print}" CHANGELOG.md > release_notes.md
+            awk "/^## \[$VERSION\]/ {flag=1; next} /^## \[/ && flag {exit} flag && /[^[:space:]]/ {print}" CHANGELOG.md > release_notes.md
             echo "Release notes extracted for version $VERSION:"
             cat release_notes.md
           else


### PR DESCRIPTION
The `Extract release notes` step filtered changelog lines with awk `/\S/`, a gawk/PCRE shorthand that **mawk does not support**. Since GitHub Actions' `ubuntu-latest` uses mawk as `/usr/bin/awk`, the filter matched nothing and the generated GitHub release body came out empty.

Use the POSIX `/[^[:space:]]/` class instead, which works in both mawk and gawk.