### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [2.1.0] - 2026-06-22
+
 - Changed: Dropped support for Ruby 3.2 (now requires Ruby >= 3.3).
 - Fixed: A malformed frame end during the connection handshake (e.g. connecting to a non-AMQP service) now raises the intended `Error::UnexpectedFrameEnd` instead of a `NameError` from a mistyped constant, which previously surfaced as a confusing `invalid handshake (uninitialized constant AMQP::Client::Error::UnexpectedFrameTypeEnd)` message
 - Fixed: The handshake now buffers the full 7-byte frame header before parsing it. On JRuby the header could arrive split across reads, leaving `frame_size` nil and raising `NoMethodError` ("undefined method '+' for nil") instead of `UnexpectedFrameEnd` when connecting to a non-AMQP service

--- a/lib/amqp/client/version.rb
+++ b/lib/amqp/client/version.rb
@@ -3,6 +3,6 @@
 module AMQP
   class Client
     # Version of the client library
-    VERSION = "2.0.1"
+    VERSION = "2.1.0"
   end
 end


### PR DESCRIPTION
Bump version to `2.1.0` and roll the `[Unreleased]` changelog entries into a dated `## [2.1.0]` section.

Highlights:

- **Changed:** dropped support for Ruby 3.2 (now requires Ruby >= 3.3)
- **Added:** `logger:` option and descriptive names for every spawned thread
- **Fixed:** several hangs/crashes around `wait_for_confirms`, abrupt socket close, untracked-delivery-tag acks, consumer channel leaks, and the non-AMQP handshake path