### PR TITLE
ci: pin Actions to SHA, simplify release workflow, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Dependabot has no native "bi-weekly" interval, and a 5-field cron can't
+      # express a true fortnight, so approximate every two weeks by checking on
+      # the 1st and 15th of each month.
+      interval: "cron"
+      cronjob: "0 6 1,15 * *"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -38,4 +38,4 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,9 +9,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ruby
       - name: Install yard
@@ -19,7 +19,7 @@ jobs:
       - name: Generate docs
         run: yard doc
       - name: Deploy docs
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: doc

--- a/.github/workflows/lavinmq.yml
+++ b/.github/workflows/lavinmq.yml
@@ -25,9 +25,9 @@ jobs:
           - { ruby: truffleruby }
     steps:
     - name: Install LavinMQ
-      uses: cloudamqp/lavinmq-action@v1
-    - uses: actions/checkout@v6
-    - uses: ruby/setup-ruby@v1
+      uses: cloudamqp/lavinmq-action@df2d45f4374c5afe2d536fd78c26c4e394315035 # v1.1.0
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}
@@ -52,9 +52,9 @@ jobs:
           - "truffleruby"
     steps:
     - name: Install LavinMQ
-      uses: cloudamqp/lavinmq-action@v1
-    - uses: actions/checkout@v6
-    - uses: ruby/setup-ruby@v1
+      uses: cloudamqp/lavinmq-action@df2d45f4374c5afe2d536fd78c26c4e394315035 # v1.1.0
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}
@@ -82,8 +82,8 @@ jobs:
         brew install lavinmq
     - name: Start LavinMQ
       run: brew services start lavinmq
-    - uses: actions/checkout@v6
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v6
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         bundler-cache: true
         ruby-version: ruby

--- a/.github/workflows/rabbitmq.yml
+++ b/.github/workflows/rabbitmq.yml
@@ -34,8 +34,8 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y rabbitmq-server
     - name: Verify RabbitMQ started correctly
       run: while true; do sudo rabbitmq-diagnostics status 2>/dev/null && break; echo -n .; sleep 2; done
-    - uses: actions/checkout@v5
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}
@@ -69,8 +69,8 @@ jobs:
         echo 'path-exclude /usr/share/man/*' | sudo tee -a /etc/dpkg/dpkg.cfg.d/01_nodoc
     - name: Install RabbitMQ
       run: sudo apt-get update && sudo apt-get install -y rabbitmq-server
-    - uses: actions/checkout@v5
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}
@@ -96,8 +96,8 @@ jobs:
       run: brew install rabbitmq
     - name: Start RabbitMQ
       run: brew services start rabbitmq
-    - uses: actions/checkout@v5
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,29 +26,17 @@ jobs:
       - run: gem install *.gem
       - run: gem push *.gem
 
-      # create GitHub release
-      - name: Extract release notes
-        id: extract_release_notes
+      # create a GitHub release, with notes for this version from the changelog
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Extract version from tag (remove 'v' prefix)
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-          # Extract changelog section for this version with better handling
-          if grep -q "## \[$VERSION\]" CHANGELOG.md; then
-            awk "/^## \[$VERSION\]/ {flag=1; next} /^## \[/ && flag {exit} flag && /[^[:space:]]/ {print}" CHANGELOG.md > release_notes.md
-            echo "Release notes extracted for version $VERSION:"
-            cat release_notes.md
+          version=${GITHUB_REF_NAME#v}
+          if grep -q "## \[$version\]" CHANGELOG.md; then
+            awk "/^## \[$version\]/ {flag=1; next} /^## \[/ && flag {exit} flag && /[^[:space:]]/ {print}" CHANGELOG.md > release_notes.md
           else
-            echo "No changelog entry found for version $VERSION" > release_notes.md
-            echo "Warning: No changelog entry found for version $VERSION"
+            echo "No changelog entry found for version $version" > release_notes.md
           fi
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
-        with:
-          name: Release ${{ steps.extract_release_notes.outputs.version }}
-          body_path: release_notes.md
-          draft: false
-          prerelease: false
-          files: '*.gem'
+          gh release create "$GITHUB_REF_NAME" *.gem \
+            --title "Release $version" \
+            --notes-file release_notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
       id-token: write # for trusted publishing
       contents: write # for creating releases
     steps:
-      - uses: actions/checkout@v5
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           bundler-cache: true
           ruby-version: ruby
-      - uses: rubygems/configure-rubygems-credentials@v1.0.0
+      - uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
       - run: ruby -v
       # ensure gem can be built and installed, push to rubygems.org
       - run: gem build *.gemspec
@@ -45,7 +45,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           name: Release ${{ steps.extract_release_notes.outputs.version }}
           body_path: release_notes.md


### PR DESCRIPTION
Hardens and tidies the GitHub Actions setup.

- **Pin all actions to a commit SHA** (version kept as a trailing comment) so a
  moved or compromised tag can't change what runs in CI. Bumped each to its
  latest release at the same time — `checkout` → v7.0.0, `codeql-action` →
  v3.36.2, `setup-ruby` → v1.314.0, `github-pages-deploy-action` → v4.8.0,
  `lavinmq-action` → v1.1.0, `configure-rubygems-credentials` → v2.1.0.
- **Simplify `release.yml`**: replace the third-party `softprops/action-gh-release`
  with `gh release create`, which ships on the runner and uses the built-in
  token. Behaviour unchanged (notes from CHANGELOG, `Release <version>` title,
  `*.gem` attached).
- **Add `.github/dependabot.yml`** to update the actions on a ~bi-weekly cadence.
  Dependabot has no native bi-weekly interval, so it uses a `cron` schedule on
  the 1st and 15th of each month.