### PR TITLE
Test LavinMQ flow control; mark Connection.Blocked tests RabbitMQ-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,6 @@ jobs:
     name: LavinMQ / macOS
     runs-on: macos-latest
     timeout-minutes: 10
-    env:
-      RUN_LAVINMQ_FLOW_CONTROL_TESTS: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         run: bundle exec rake
 
   rabbitmq-tests:
-    name: "RabbitMQ / ${{ matrix.ruby }} (blocked: ${{ matrix.blocked_tests }})"
+    name: RabbitMQ / ${{ matrix.ruby }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -143,13 +143,13 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
-      - name: Run tests (excluding TLS tests) (JRuby)
+      - name: "Run tests (excluding TLS tests, blocked: ${{ matrix.blocked_tests }}) (JRuby)"
         if: ${{ matrix.ruby == 'jruby' }}
         continue-on-error: ${{ matrix.allow-failure || false }}
         run: bundle exec rake
         env:
           JAVA_OPTS: "-Djava.net.preferIPv4Stack=true"
-      - name: Run tests (excluding TLS tests)
+      - name: "Run tests (excluding TLS tests, blocked: ${{ matrix.blocked_tests }})"
         if: ${{ matrix.ruby != 'jruby' }}
         continue-on-error: ${{ matrix.allow-failure || false }}
         run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      RUN_RABBITMQ_BLOCKED_TESTS: ${{ matrix.blocked_tests }}
+      RUN_RABBITMQ_CONNECTION_BLOCKED_TESTS: ${{ matrix.connection_blocked_tests }}
     strategy:
       fail-fast: false
       matrix:
-        blocked_tests:
+        connection_blocked_tests:
           - true
         ruby:
           - "3.3"
@@ -125,10 +125,10 @@ jobs:
         include:
           - ruby: jruby
             allow-failure: false
-            blocked_tests: false
+            connection_blocked_tests: false
           - ruby: truffleruby
             allow-failure: false
-            blocked_tests: false
+            connection_blocked_tests: false
     steps:
       - name: Configure dpkg to skip building man pages
         run: |
@@ -143,13 +143,13 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
-      - name: "Run tests (excluding TLS tests, blocked: ${{ matrix.blocked_tests }}) (JRuby)"
+      - name: "Run tests (no TLS, Connection.Blocked: ${{ matrix.connection_blocked_tests }}) (JRuby)"
         if: ${{ matrix.ruby == 'jruby' }}
         continue-on-error: ${{ matrix.allow-failure || false }}
         run: bundle exec rake
         env:
           JAVA_OPTS: "-Djava.net.preferIPv4Stack=true"
-      - name: "Run tests (excluding TLS tests, blocked: ${{ matrix.blocked_tests }})"
+      - name: "Run tests (no TLS, Connection.Blocked: ${{ matrix.connection_blocked_tests }})"
         if: ${{ matrix.ruby != 'jruby' }}
         continue-on-error: ${{ matrix.allow-failure || false }}
         run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,13 +110,15 @@ jobs:
         run: bundle exec rake
 
   rabbitmq-tests:
-    name: "RabbitMQ / ${{ matrix.ruby }} (sudo: ${{ matrix.sudo }})"
+    name: "RabbitMQ / ${{ matrix.ruby }} (blocked: ${{ matrix.blocked_tests }})"
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      RUN_RABBITMQ_BLOCKED_TESTS: ${{ matrix.blocked_tests }}
     strategy:
       fail-fast: false
       matrix:
-        sudo:
+        blocked_tests:
           - true
         ruby:
           - "3.3"
@@ -125,10 +127,10 @@ jobs:
         include:
           - ruby: jruby
             allow-failure: false
-            sudo: false
+            blocked_tests: false
           - ruby: truffleruby
             allow-failure: false
-            sudo: false
+            blocked_tests: false
     steps:
       - name: Configure dpkg to skip building man pages
         run: |
@@ -153,8 +155,6 @@ jobs:
         if: ${{ matrix.ruby != 'jruby' }}
         continue-on-error: ${{ matrix.allow-failure || false }}
         run: bundle exec rake
-        env:
-          RUN_SUDO_TESTS: ${{ matrix.sudo }}
 
   rabbitmq-tls:
     name: RabbitMQ TLS / ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     name: LavinMQ / ${{ matrix.ruby }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      RUN_LAVINMQ_FLOW_CONTROL_TESTS: "1"
     strategy:
       fail-fast: false
       matrix:
@@ -85,6 +87,8 @@ jobs:
     name: LavinMQ / macOS
     runs-on: macos-latest
     timeout-minutes: 10
+    env:
+      RUN_LAVINMQ_FLOW_CONTROL_TESTS: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -198,10 +198,10 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ### RabbitMQ Connection.Blocked tests
 
-The RabbitMQ `Connection.Blocked` tests change the broker memory watermark with `sudo rabbitmqctl`. They are skipped unless `RUN_RABBITMQ_BLOCKED_TESTS` is set to `1` or `true`:
+The RabbitMQ `Connection.Blocked` tests change the broker memory watermark with `sudo rabbitmqctl`. They are skipped unless `RUN_RABBITMQ_CONNECTION_BLOCKED_TESTS` is set to `1` or `true`:
 
 ```bash
-RUN_RABBITMQ_BLOCKED_TESTS=1 bundle exec rake test
+RUN_RABBITMQ_CONNECTION_BLOCKED_TESTS=1 bundle exec rake test
 ```
 
 ### LavinMQ flow-control tests

--- a/README.md
+++ b/README.md
@@ -196,6 +196,16 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 
+### LavinMQ flow-control tests
+
+The LavinMQ flow-control test starts a private LavinMQ instance configured to reject publishes due to low disk space. It is skipped unless `RUN_LAVINMQ_FLOW_CONTROL_TESTS` is set to `1` or `true`:
+
+```bash
+RUN_LAVINMQ_FLOW_CONTROL_TESTS=1 bundle exec rake test
+```
+
+Current LavinMQ releases hardcode their control socket at `/tmp/lavinmqctl.sock`, so the helper clears that socket before startup. A LavinMQ you already have running keeps serving AMQP but loses its `lavinmqctl` socket until restarted. The workaround can be removed when LavinMQ 2.9.0 is released with https://github.com/cloudamqp/lavinmq/pull/2029. CI opts in for the LavinMQ test jobs.
+
 ### TLS tests
 
 `rake test` excludes the TLS tests because they need a broker with TLS enabled. `bin/test-tls` runs them against a throwaway broker without disturbing anything you already have set up: it generates a self-signed certificate, starts the broker as your user from a temporary directory on non-default ports (21672/21671), runs the `_tls` tests, then shuts it down. With no argument it tests both brokers in turn:

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The LavinMQ flow-control test starts a private LavinMQ instance configured to re
 RUN_LAVINMQ_FLOW_CONTROL_TESTS=1 bundle exec rake test
 ```
 
-Current LavinMQ releases hardcode their control socket at `/tmp/lavinmqctl.sock`, so the helper clears that socket before startup. A LavinMQ you already have running keeps serving AMQP but loses its `lavinmqctl` socket until restarted. The workaround can be removed when LavinMQ 2.9.0 is released with https://github.com/cloudamqp/lavinmq/pull/2029. CI opts in for the LavinMQ test jobs.
+CI opts in for the LavinMQ test jobs.
 
 ### TLS tests
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The LavinMQ flow-control test starts a private LavinMQ instance configured to re
 RUN_LAVINMQ_FLOW_CONTROL_TESTS=1 bundle exec rake test
 ```
 
-CI opts in for the LavinMQ test jobs.
+CI opts in for the Linux LavinMQ test jobs.
 
 ### TLS tests
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 
+### RabbitMQ Connection.Blocked tests
+
+The RabbitMQ `Connection.Blocked` tests change the broker memory watermark with `sudo rabbitmqctl`. They are skipped unless `RUN_RABBITMQ_BLOCKED_TESTS` is set to `1` or `true`:
+
+```bash
+RUN_RABBITMQ_BLOCKED_TESTS=1 bundle exec rake test
+```
+
 ### LavinMQ flow-control tests
 
 The LavinMQ flow-control test starts a private LavinMQ instance configured to reject publishes due to low disk space. It is skipped unless `RUN_LAVINMQ_FLOW_CONTROL_TESTS` is set to `1` or `true`:

--- a/test/amqp/client_lifecycle_test.rb
+++ b/test/amqp/client_lifecycle_test.rb
@@ -465,7 +465,7 @@ class AMQPClientLifecycleTest < Minitest::Test
   # RabbitMQ-only: exercises Connection.Blocked. LavinMQ doesn't implement it
   # (its low-resource back-pressure is a 406 channel error instead).
   def test_it_can_be_blocked
-    skip_unless_rabbitmq_blocked_tests
+    skip_unless_rabbitmq_connection_blocked_tests
     begin
       ch = @connection.channel
       system("sudo rabbitmqctl set_vm_memory_high_watermark 0.001")
@@ -518,7 +518,7 @@ class AMQPClientLifecycleTest < Minitest::Test
 
   # RabbitMQ-only: exercises the Connection.Blocked/Unblocked callbacks.
   def test_blocked_handler
-    skip_unless_rabbitmq_blocked_tests
+    skip_unless_rabbitmq_connection_blocked_tests
     begin
       q = Queue.new
       @connection.on_blocked do |reason|

--- a/test/amqp/client_lifecycle_test.rb
+++ b/test/amqp/client_lifecycle_test.rb
@@ -465,8 +465,7 @@ class AMQPClientLifecycleTest < Minitest::Test
   # RabbitMQ-only: exercises Connection.Blocked. LavinMQ doesn't implement it
   # (its low-resource back-pressure is a 406 channel error instead).
   def test_it_can_be_blocked
-    skip_unless_rabbitmqctl
-    skip_if_no_sudo
+    skip_unless_rabbitmq_blocked_tests
     begin
       ch = @connection.channel
       system("sudo rabbitmqctl set_vm_memory_high_watermark 0.001")
@@ -519,8 +518,7 @@ class AMQPClientLifecycleTest < Minitest::Test
 
   # RabbitMQ-only: exercises the Connection.Blocked/Unblocked callbacks.
   def test_blocked_handler
-    skip_unless_rabbitmqctl
-    skip_if_no_sudo
+    skip_unless_rabbitmq_blocked_tests
     begin
       q = Queue.new
       @connection.on_blocked do |reason|

--- a/test/amqp/client_lifecycle_test.rb
+++ b/test/amqp/client_lifecycle_test.rb
@@ -462,7 +462,10 @@ class AMQPClientLifecycleTest < Minitest::Test
     end
   end
 
+  # RabbitMQ-only: exercises Connection.Blocked. LavinMQ doesn't implement it
+  # (its low-resource back-pressure is a 406 channel error instead).
   def test_it_can_be_blocked
+    skip_unless_rabbitmqctl
     skip_if_no_sudo
     begin
       ch = @connection.channel
@@ -514,7 +517,9 @@ class AMQPClientLifecycleTest < Minitest::Test
     assert_equal props, msg.properties
   end
 
+  # RabbitMQ-only: exercises the Connection.Blocked/Unblocked callbacks.
   def test_blocked_handler
+    skip_unless_rabbitmqctl
     skip_if_no_sudo
     begin
       q = Queue.new

--- a/test/amqp/lavinmq_flow_control_test.rb
+++ b/test/amqp/lavinmq_flow_control_test.rb
@@ -16,4 +16,34 @@ class AMQPLavinMQFlowControlTest < Minitest::Test
       end
     end
   end
+
+  def test_low_disk_lavinmq_startup_error_includes_broker_output
+    Dir.mktmpdir("fake-lavinmq") do |dir|
+      exe = File.join(dir, "lavinmq")
+      File.write(exe, <<~RUBY)
+        #!/usr/bin/env ruby
+        puts "fake stdout"
+        warn "fake stderr"
+        exit 42
+      RUBY
+      FileUtils.chmod(0o755, exe)
+
+      error = assert_raises(RuntimeError) do
+        send(:start_low_disk_lavinmq, exe, dir)
+      end
+
+      expected = Regexp.new(
+        [
+          "lavinmq did not start after 3 attempts",
+          "at=error attempt=1",
+          "reason=exited exit_status=42",
+          "fake stdout",
+          "fake stderr"
+        ].join(".*"),
+        Regexp::MULTILINE
+      )
+
+      assert_match expected, error.message
+    end
+  end
 end

--- a/test/amqp/lavinmq_flow_control_test.rb
+++ b/test/amqp/lavinmq_flow_control_test.rb
@@ -8,7 +8,6 @@ class AMQPLavinMQFlowControlTest < Minitest::Test
       conn = AMQP::Client.new("amqp://127.0.0.1:#{port}").connect
       begin
         ch = conn.channel
-        ch.confirm_select
         assert_raises(AMQP::Client::Error::PreconditionFailed) do
           ch.basic_publish_confirm("body", exchange: "", routing_key: "low.disk.test")
         end

--- a/test/amqp/lavinmq_flow_control_test.rb
+++ b/test/amqp/lavinmq_flow_control_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class AMQPLavinMQFlowControlTest < Minitest::Test
+  def test_low_disk_blocks_publishing_with_precondition_failed
+    with_low_disk_lavinmq do |port|
+      conn = AMQP::Client.new("amqp://127.0.0.1:#{port}").connect
+      begin
+        ch = conn.channel
+        ch.confirm_select
+        assert_raises(AMQP::Client::Error::PreconditionFailed) do
+          ch.basic_publish_confirm("body", exchange: "", routing_key: "low.disk.test")
+        end
+      ensure
+        conn&.close
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -185,11 +185,15 @@ module LavinMQServer
   end
 
   def spawn_lavinmq(exe, config, amqp_port)
+    control_socket = File.join(File.dirname(config), "lavinmqctl.sock")
+
     spawn(exe, "--config", config,
           "--amqp-port", amqp_port.to_s, "--amqps-port", "-1",
           "--http-port", "-1", "--https-port", "-1",
           "--mqtt-port", "-1", "--mqtts-port", "-1",
-          "--metrics-http-port", "-1", "--bind", "127.0.0.1",
+          "--metrics-http-port", "-1",
+          "--control-unix-path", control_socket,
+          "--bind", "127.0.0.1",
           out: File::NULL, err: File::NULL)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -206,7 +206,8 @@ module LavinMQServer
     nil
   end
 
-  # Reserve `count` distinct free ports by holding all the sockets open at once.
+  # Probe distinct ports for the child process to bind. These are available when
+  # probed, but not reserved after this method returns.
   def free_tcp_ports(count)
     servers = Array.new(count) { TCPServer.new("127.0.0.1", 0) }
     servers.map { |s| s.addr[1] }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -129,8 +129,7 @@ module ReadLoopHelpers
   end
 end
 
-# Boots a throwaway LavinMQ instance for tests that need broker behaviour we
-# can't toggle on the shared server. These tests are opt-in.
+# Boots a throwaway LavinMQ instance for tests that need specific broker configuration. These tests are opt-in.
 module LavinMQServer
   LAVINMQ_FLOW_CONTROL_OPT_IN = "RUN_LAVINMQ_FLOW_CONTROL_TESTS"
   LAVINMQ_STARTUP_ATTEMPTS = 3

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -130,10 +130,8 @@ module ReadLoopHelpers
 end
 
 # Boots a throwaway LavinMQ instance for tests that need broker behaviour we
-# can't toggle on the shared server. These tests are opt-in because starting a
-# second LavinMQ currently requires clearing the hardcoded control socket path.
+# can't toggle on the shared server. These tests are opt-in.
 module LavinMQServer
-  LAVINMQ_CONTROL_SOCKET = "/tmp/lavinmqctl.sock"
   LAVINMQ_FLOW_CONTROL_OPT_IN = "RUN_LAVINMQ_FLOW_CONTROL_TESTS"
   LAVINMQ_STARTUP_ATTEMPTS = 3
   LAVINMQ_STARTUP_TIMEOUT = 10
@@ -161,7 +159,6 @@ module LavinMQServer
     yield amqp_port
   ensure
     stop_process(pid, waiter)
-    clear_lavinmq_control_socket(required: false)
     FileUtils.remove_entry(dir) if dir
   end
 
@@ -169,7 +166,6 @@ module LavinMQServer
     LAVINMQ_STARTUP_ATTEMPTS.times do |attempt|
       amqp_port = free_tcp_port
       config = write_low_disk_lavinmq_config(dir, attempt + 1)
-      clear_lavinmq_control_socket(required: true)
       pid = spawn_lavinmq(exe, config, amqp_port)
       waiter = Process.detach(pid)
       return [pid, waiter, amqp_port] if wait_for_tcp("127.0.0.1", amqp_port, waiter:)
@@ -201,16 +197,6 @@ module LavinMQServer
     return if %w[1 true].include?(ENV[LAVINMQ_FLOW_CONTROL_OPT_IN])
 
     skip "set #{LAVINMQ_FLOW_CONTROL_OPT_IN}=1 to run LavinMQ flow-control tests"
-  end
-
-  # LavinMQ < 2.9.0 hardcodes its control socket at /tmp/lavinmqctl.sock and
-  # aborts at startup if it can't recreate it. This can be removed when LavinMQ
-  # 2.9.0 is released with https://github.com/cloudamqp/lavinmq/pull/2029.
-  def clear_lavinmq_control_socket(required:)
-    return if system("rm", "-f", LAVINMQ_CONTROL_SOCKET, out: File::NULL, err: File::NULL)
-    return if system("sudo", "-n", "rm", "-f", LAVINMQ_CONTROL_SOCKET, out: File::NULL, err: File::NULL)
-
-    skip "requires removing #{LAVINMQ_CONTROL_SOCKET}" if required
   end
 
   def lavinmq_executable

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,7 +62,7 @@ module SkipRabbitMQTestCase
   def skip_unless_rabbitmqctl
     return if rabbitmqctl?
 
-    skip "requires RabbitMQ; rabbitmqctl not found (LavinMQ doesn't send Connection.Blocked)"
+    skip "requires RabbitMQ; rabbitmqctl not found"
   end
 
   def rabbitmqctl?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,25 +49,13 @@ module TimeoutEveryTestCase
   end
 end
 
-module SkipSudoTestCase
-  def skip_if_no_sudo
-    skip "requires sudo" unless %w[1 true].include?(ENV["RUN_SUDO_TESTS"])
-  end
-end
+module RabbitMQBlockedTestCase
+  RABBITMQ_BLOCKED_TESTS_OPT_IN = "RUN_RABBITMQ_BLOCKED_TESTS"
 
-# For tests that exercise RabbitMQ-only broker behaviour (e.g. Connection.Blocked,
-# which LavinMQ doesn't implement). rabbitmqctl on PATH is the signal that we're
-# running against RabbitMQ; its apt package installs it under /usr/sbin.
-module SkipRabbitMQTestCase
-  def skip_unless_rabbitmqctl
-    return if rabbitmqctl?
+  def skip_unless_rabbitmq_blocked_tests
+    return if %w[1 true].include?(ENV[RABBITMQ_BLOCKED_TESTS_OPT_IN])
 
-    skip "requires RabbitMQ; rabbitmqctl not found"
-  end
-
-  def rabbitmqctl?
-    search = ENV["PATH"].to_s.split(File::PATH_SEPARATOR) + %w[/usr/sbin /usr/local/sbin /sbin]
-    search.any? { |dir| File.executable?(File.join(dir, "rabbitmqctl")) }
+    skip "set #{RABBITMQ_BLOCKED_TESTS_OPT_IN}=1 to run RabbitMQ Connection.Blocked tests"
   end
 end
 
@@ -305,8 +293,7 @@ end
 $VERBOSE = nil unless ENV["DEBUG"] == "true"
 
 Minitest::Test.prepend TimeoutEveryTestCase
-Minitest::Test.prepend SkipSudoTestCase
-Minitest::Test.prepend SkipRabbitMQTestCase
+Minitest::Test.prepend RabbitMQBlockedTestCase
 Minitest::Test.prepend FakeServer
 Minitest::Test.prepend ThreadHelpers
 Minitest::Test.prepend ReadLoopHelpers

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,7 +49,7 @@ module TimeoutEveryTestCase
   end
 end
 
-module RabbitMQBlockedTestCase
+module RabbitMQConnectionBlockedTestCase
   RABBITMQ_CONNECTION_BLOCKED_TESTS_OPT_IN = "RUN_RABBITMQ_CONNECTION_BLOCKED_TESTS"
 
   def skip_unless_rabbitmq_connection_blocked_tests
@@ -316,7 +316,7 @@ end
 $VERBOSE = nil unless ENV["DEBUG"] == "true"
 
 Minitest::Test.prepend TimeoutEveryTestCase
-Minitest::Test.prepend RabbitMQBlockedTestCase
+Minitest::Test.prepend RabbitMQConnectionBlockedTestCase
 Minitest::Test.prepend FakeServer
 Minitest::Test.prepend ThreadHelpers
 Minitest::Test.prepend ReadLoopHelpers

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -147,6 +147,8 @@ end
 module LavinMQServer
   LAVINMQ_CONTROL_SOCKET = "/tmp/lavinmqctl.sock"
   LAVINMQ_FLOW_CONTROL_OPT_IN = "RUN_LAVINMQ_FLOW_CONTROL_TESTS"
+  LAVINMQ_STARTUP_ATTEMPTS = 3
+  LAVINMQ_STARTUP_TIMEOUT = 10
   PROCESS_SHUTDOWN_TIMEOUT = 5
 
   # Yields the AMQP port of a private LavinMQ that believes it is out of disk
@@ -167,20 +169,44 @@ module LavinMQServer
   # AMQP port, then tear it down.
   def boot_low_disk_lavinmq(exe)
     dir = Dir.mktmpdir("lavinmq-lowdisk")
-    amqp_port, http_port, mqtt_port, metrics_port = free_tcp_ports(4)
-    File.write(File.join(dir, "lavinmq.ini"),
-               "[main]\ndata_dir = #{dir}/data\nfree_disk_min = 1000000000000000\n")
-    clear_lavinmq_control_socket(required: true)
-    pid = spawn(exe, "--config", File.join(dir, "lavinmq.ini"),
-                "--amqp-port", amqp_port.to_s, "--http-port", http_port.to_s,
-                "--mqtt-port", mqtt_port.to_s, "--metrics-http-port", metrics_port.to_s,
-                "--bind", "127.0.0.1", out: File::NULL, err: File::NULL)
-    wait_for_tcp("127.0.0.1", amqp_port)
+    pid, waiter, amqp_port = start_low_disk_lavinmq(exe, dir)
     yield amqp_port
   ensure
-    stop_process(pid)
+    stop_process(pid, waiter)
     clear_lavinmq_control_socket(required: false)
     FileUtils.remove_entry(dir) if dir
+  end
+
+  def start_low_disk_lavinmq(exe, dir)
+    LAVINMQ_STARTUP_ATTEMPTS.times do |attempt|
+      amqp_port = free_tcp_port
+      config = write_low_disk_lavinmq_config(dir, attempt + 1)
+      clear_lavinmq_control_socket(required: true)
+      pid = spawn_lavinmq(exe, config, amqp_port)
+      waiter = Process.detach(pid)
+      return [pid, waiter, amqp_port] if wait_for_tcp("127.0.0.1", amqp_port, waiter:)
+
+      stop_process(pid, waiter)
+    end
+
+    raise "lavinmq did not start after #{LAVINMQ_STARTUP_ATTEMPTS} attempts"
+  end
+
+  def write_low_disk_lavinmq_config(dir, attempt)
+    attempt_dir = File.join(dir, "attempt-#{attempt}")
+    FileUtils.mkdir_p(attempt_dir)
+    config = File.join(attempt_dir, "lavinmq.ini")
+    File.write(config, "[main]\ndata_dir = #{attempt_dir}/data\nfree_disk_min = 1000000000000000\n")
+    config
+  end
+
+  def spawn_lavinmq(exe, config, amqp_port)
+    spawn(exe, "--config", config,
+          "--amqp-port", amqp_port.to_s, "--amqps-port", "-1",
+          "--http-port", "-1", "--https-port", "-1",
+          "--mqtt-port", "-1", "--mqtts-port", "-1",
+          "--metrics-http-port", "-1", "--bind", "127.0.0.1",
+          out: File::NULL, err: File::NULL)
   end
 
   def skip_unless_lavinmq_flow_control_tests
@@ -207,22 +233,27 @@ module LavinMQServer
     nil
   end
 
-  # Probe distinct ports for the child process to bind. These are available when
-  # probed, but not reserved after this method returns.
-  def free_tcp_ports(count)
-    servers = Array.new(count) { TCPServer.new("127.0.0.1", 0) }
-    servers.map { |s| s.addr[1] }
+  # Probe a port for the child process to bind. It is available when probed, but
+  # not reserved after this method returns.
+  def free_tcp_port
+    server = TCPServer.new("127.0.0.1", 0)
+    server.addr[1]
   ensure
-    servers&.each(&:close)
+    server&.close
   end
 
-  def wait_for_tcp(host, port, timeout: 10)
+  def wait_for_tcp(host, port, timeout: LAVINMQ_STARTUP_TIMEOUT, waiter: nil)
     deadline = monotonic_now + timeout
     loop do
+      return false if waiter&.join(0)
+
       Socket.tcp(host, port, connect_timeout: 1).close
-      return
+      return false if waiter&.join(0)
+
+      return true
     rescue SystemCallError
-      raise "lavinmq did not start on #{host}:#{port}" if monotonic_now > deadline
+      return false if waiter&.join(0)
+      return false if monotonic_now > deadline
 
       sleep 0.1
     end
@@ -232,10 +263,10 @@ module LavinMQServer
     Process.clock_gettime(Process::CLOCK_MONOTONIC)
   end
 
-  def stop_process(pid)
+  def stop_process(pid, waiter = nil)
     return unless pid
 
-    waiter = Process.detach(pid)
+    waiter ||= Process.detach(pid)
     signal_process(pid, "TERM")
     return if waiter.join(PROCESS_SHUTDOWN_TIMEOUT)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -142,13 +142,18 @@ module ReadLoopHelpers
 end
 
 # Boots a throwaway LavinMQ instance for tests that need broker behaviour we
-# can't toggle on the shared server. Requires the `lavinmq` executable on PATH;
-# the test is skipped otherwise (e.g. when running against RabbitMQ).
+# can't toggle on the shared server. These tests are opt-in because starting a
+# second LavinMQ currently requires clearing the hardcoded control socket path.
 module LavinMQServer
+  LAVINMQ_CONTROL_SOCKET = "/tmp/lavinmqctl.sock"
+  LAVINMQ_FLOW_CONTROL_OPT_IN = "RUN_LAVINMQ_FLOW_CONTROL_TESTS"
+
   # Yields the AMQP port of a private LavinMQ that believes it is out of disk
   # space (free_disk_min above any real free space), so it applies flow control
   # and rejects publishes/declarations with PRECONDITION_FAILED.
   def with_low_disk_lavinmq(&)
+    skip_unless_lavinmq_flow_control_tests
+
     exe = lavinmq_executable
     skip "lavinmq executable not found" unless exe
 
@@ -164,6 +169,7 @@ module LavinMQServer
     amqp_port, http_port, mqtt_port, metrics_port = free_tcp_ports(4)
     File.write(File.join(dir, "lavinmq.ini"),
                "[main]\ndata_dir = #{dir}/data\nfree_disk_min = 1000000000000000\n")
+    clear_lavinmq_control_socket(required: true)
     pid = spawn(exe, "--config", File.join(dir, "lavinmq.ini"),
                 "--amqp-port", amqp_port.to_s, "--http-port", http_port.to_s,
                 "--mqtt-port", mqtt_port.to_s, "--metrics-http-port", metrics_port.to_s,
@@ -172,7 +178,24 @@ module LavinMQServer
     yield amqp_port
   ensure
     stop_process(pid)
+    clear_lavinmq_control_socket(required: false)
     FileUtils.remove_entry(dir) if dir
+  end
+
+  def skip_unless_lavinmq_flow_control_tests
+    return if %w[1 true].include?(ENV[LAVINMQ_FLOW_CONTROL_OPT_IN])
+
+    skip "set #{LAVINMQ_FLOW_CONTROL_OPT_IN}=1 to run LavinMQ flow-control tests"
+  end
+
+  # LavinMQ < 2.9.0 hardcodes its control socket at /tmp/lavinmqctl.sock and
+  # aborts at startup if it can't recreate it. This can be removed when LavinMQ
+  # 2.9.0 is released with https://github.com/cloudamqp/lavinmq/pull/2029.
+  def clear_lavinmq_control_socket(required:)
+    return if system("rm", "-f", LAVINMQ_CONTROL_SOCKET, out: File::NULL, err: File::NULL)
+    return if system("sudo", "-n", "rm", "-f", LAVINMQ_CONTROL_SOCKET, out: File::NULL, err: File::NULL)
+
+    skip "requires removing #{LAVINMQ_CONTROL_SOCKET}" if required
   end
 
   def lavinmq_executable

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -147,6 +147,7 @@ end
 module LavinMQServer
   LAVINMQ_CONTROL_SOCKET = "/tmp/lavinmqctl.sock"
   LAVINMQ_FLOW_CONTROL_OPT_IN = "RUN_LAVINMQ_FLOW_CONTROL_TESTS"
+  PROCESS_SHUTDOWN_TIMEOUT = 5
 
   # Yields the AMQP port of a private LavinMQ that believes it is out of disk
   # space (free_disk_min above any real free space), so it applies flow control
@@ -234,9 +235,19 @@ module LavinMQServer
   def stop_process(pid)
     return unless pid
 
-    Process.kill("TERM", pid)
-    Process.wait(pid)
-  rescue Errno::ESRCH, Errno::ECHILD
+    waiter = Process.detach(pid)
+    signal_process(pid, "TERM")
+    return if waiter.join(PROCESS_SHUTDOWN_TIMEOUT)
+
+    signal_process(pid, "KILL")
+    waiter.join(PROCESS_SHUTDOWN_TIMEOUT)
+  rescue Errno::ECHILD
+    nil
+  end
+
+  def signal_process(pid, signal)
+    Process.kill(signal, pid)
+  rescue Errno::ESRCH
     nil
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,7 +55,26 @@ module SkipSudoTestCase
   end
 end
 
+# For tests that exercise RabbitMQ-only broker behaviour (e.g. Connection.Blocked,
+# which LavinMQ doesn't implement). rabbitmqctl on PATH is the signal that we're
+# running against RabbitMQ; its apt package installs it under /usr/sbin.
+module SkipRabbitMQTestCase
+  def skip_unless_rabbitmqctl
+    return if rabbitmqctl?
+
+    skip "requires RabbitMQ; rabbitmqctl not found (LavinMQ doesn't send Connection.Blocked)"
+  end
+
+  def rabbitmqctl?
+    search = ENV["PATH"].to_s.split(File::PATH_SEPARATOR) + %w[/usr/sbin /usr/local/sbin /sbin]
+    search.any? { |dir| File.executable?(File.join(dir, "rabbitmqctl")) }
+  end
+end
+
 require "socket"
+require "tmpdir"
+require "fileutils"
+
 module FakeServer
   def with_fake_server(host: "127.0.0.1")
     server = TCPServer.new(host, 0)
@@ -122,6 +141,82 @@ module ReadLoopHelpers
   end
 end
 
+# Boots a throwaway LavinMQ instance for tests that need broker behaviour we
+# can't toggle on the shared server. Requires the `lavinmq` executable on PATH;
+# the test is skipped otherwise (e.g. when running against RabbitMQ).
+module LavinMQServer
+  # Yields the AMQP port of a private LavinMQ that believes it is out of disk
+  # space (free_disk_min above any real free space), so it applies flow control
+  # and rejects publishes/declarations with PRECONDITION_FAILED.
+  def with_low_disk_lavinmq(&)
+    exe = lavinmq_executable
+    skip "lavinmq executable not found" unless exe
+
+    boot_low_disk_lavinmq(exe, &)
+  end
+
+  private
+
+  # Spawn a private LavinMQ with free_disk_min above real free space, yield its
+  # AMQP port, then tear it down.
+  def boot_low_disk_lavinmq(exe)
+    dir = Dir.mktmpdir("lavinmq-lowdisk")
+    amqp_port, http_port, mqtt_port, metrics_port = free_tcp_ports(4)
+    File.write(File.join(dir, "lavinmq.ini"),
+               "[main]\ndata_dir = #{dir}/data\nfree_disk_min = 1000000000000000\n")
+    pid = spawn(exe, "--config", File.join(dir, "lavinmq.ini"),
+                "--amqp-port", amqp_port.to_s, "--http-port", http_port.to_s,
+                "--mqtt-port", mqtt_port.to_s, "--metrics-http-port", metrics_port.to_s,
+                "--bind", "127.0.0.1", out: File::NULL, err: File::NULL)
+    wait_for_tcp("127.0.0.1", amqp_port)
+    yield amqp_port
+  ensure
+    stop_process(pid)
+    FileUtils.remove_entry(dir) if dir
+  end
+
+  def lavinmq_executable
+    ENV["PATH"].to_s.split(File::PATH_SEPARATOR).each do |dir|
+      exe = File.join(dir, "lavinmq")
+      return exe if File.executable?(exe)
+    end
+    nil
+  end
+
+  # Reserve `count` distinct free ports by holding all the sockets open at once.
+  def free_tcp_ports(count)
+    servers = Array.new(count) { TCPServer.new("127.0.0.1", 0) }
+    servers.map { |s| s.addr[1] }
+  ensure
+    servers&.each(&:close)
+  end
+
+  def wait_for_tcp(host, port, timeout: 10)
+    deadline = monotonic_now + timeout
+    loop do
+      Socket.tcp(host, port, connect_timeout: 1).close
+      return
+    rescue SystemCallError
+      raise "lavinmq did not start on #{host}:#{port}" if monotonic_now > deadline
+
+      sleep 0.1
+    end
+  end
+
+  def monotonic_now
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def stop_process(pid)
+    return unless pid
+
+    Process.kill("TERM", pid)
+    Process.wait(pid)
+  rescue Errno::ESRCH, Errno::ECHILD
+    nil
+  end
+end
+
 # Socket stand-in that hands out preset byte chunks across successive reads,
 # so tests can drive the handshake parser deterministically (no real network,
 # no timing). Used to reproduce frame headers that arrive split across reads.
@@ -145,6 +240,8 @@ $VERBOSE = nil unless ENV["DEBUG"] == "true"
 
 Minitest::Test.prepend TimeoutEveryTestCase
 Minitest::Test.prepend SkipSudoTestCase
+Minitest::Test.prepend SkipRabbitMQTestCase
 Minitest::Test.prepend FakeServer
 Minitest::Test.prepend ThreadHelpers
 Minitest::Test.prepend ReadLoopHelpers
+Minitest::Test.prepend LavinMQServer

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -129,11 +129,13 @@ module ReadLoopHelpers
   end
 end
 
-# Boots a throwaway LavinMQ instance for tests that need specific broker configuration. These tests are opt-in.
+# Boots a throwaway LavinMQ instance for tests that need specific broker
+# configuration. These tests are opt-in.
 module LavinMQServer
   LAVINMQ_FLOW_CONTROL_OPT_IN = "RUN_LAVINMQ_FLOW_CONTROL_TESTS"
   LAVINMQ_STARTUP_ATTEMPTS = 3
   LAVINMQ_STARTUP_TIMEOUT = 10
+  LAVINMQ_STARTUP_LOG_LINES = 80
   PROCESS_SHUTDOWN_TIMEOUT = 5
 
   # Yields the AMQP port of a private LavinMQ that believes it is out of disk
@@ -162,17 +164,23 @@ module LavinMQServer
   end
 
   def start_low_disk_lavinmq(exe, dir)
+    failures = []
+
     LAVINMQ_STARTUP_ATTEMPTS.times do |attempt|
       amqp_port = free_tcp_port
       config = write_low_disk_lavinmq_config(dir, attempt + 1)
-      pid = spawn_lavinmq(exe, config, amqp_port)
+      stdout = File.join(File.dirname(config), "lavinmq.stdout.log")
+      stderr = File.join(File.dirname(config), "lavinmq.stderr.log")
+      pid = spawn_lavinmq(exe, config, amqp_port, stdout:, stderr:)
       waiter = Process.detach(pid)
       return [pid, waiter, amqp_port] if wait_for_tcp("127.0.0.1", amqp_port, waiter:)
 
+      status = waiter.join(0)&.value
       stop_process(pid, waiter)
+      failures << lavinmq_startup_failure(attempt + 1, amqp_port, config, stdout, stderr, status)
     end
 
-    raise "lavinmq did not start after #{LAVINMQ_STARTUP_ATTEMPTS} attempts"
+    raise "lavinmq did not start after #{LAVINMQ_STARTUP_ATTEMPTS} attempts\n\n#{failures.join("\n\n")}"
   end
 
   def write_low_disk_lavinmq_config(dir, attempt)
@@ -183,7 +191,7 @@ module LavinMQServer
     config
   end
 
-  def spawn_lavinmq(exe, config, amqp_port)
+  def spawn_lavinmq(exe, config, amqp_port, stdout:, stderr:)
     control_socket = File.join(File.dirname(config), "lavinmqctl.sock")
 
     spawn(exe, "--config", config,
@@ -191,9 +199,35 @@ module LavinMQServer
           "--http-port", "-1", "--https-port", "-1",
           "--mqtt-port", "-1", "--mqtts-port", "-1",
           "--metrics-http-port", "-1",
+          "--clustering-port", "0",
           "--control-unix-path", control_socket,
           "--bind", "127.0.0.1",
-          out: File::NULL, err: File::NULL)
+          out: [stdout, "w"], err: [stderr, "w"])
+  end
+
+  def lavinmq_startup_failure(attempt, amqp_port, config, stdout, stderr, status)
+    [
+      "at=error attempt=#{attempt} amqp_port=#{amqp_port} config=#{config} #{lavinmq_startup_reason(status)}",
+      lavinmq_log_excerpt("stdout", stdout),
+      lavinmq_log_excerpt("stderr", stderr)
+    ].join("\n")
+  end
+
+  def lavinmq_startup_reason(status)
+    return "reason=startup_timeout timeout=#{LAVINMQ_STARTUP_TIMEOUT}s" unless status
+    return "reason=exited exit_status=#{status.exitstatus}" if status.exited?
+    return "reason=signaled termsig=#{status.termsig}" if status.signaled?
+
+    "reason=unknown process_status=#{status}"
+  end
+
+  def lavinmq_log_excerpt(stream, path)
+    lines = File.readlines(path, chomp: true).last(LAVINMQ_STARTUP_LOG_LINES)
+    return "#{stream}=empty path=#{path}" if lines.empty?
+
+    "#{stream}=#{path} tail_lines=#{lines.length}\n#{lines.join("\n")}"
+  rescue SystemCallError => e
+    "#{stream}=unreadable path=#{path} error=#{e.class}:#{e.message}"
   end
 
   def skip_unless_lavinmq_flow_control_tests

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,12 +50,12 @@ module TimeoutEveryTestCase
 end
 
 module RabbitMQBlockedTestCase
-  RABBITMQ_BLOCKED_TESTS_OPT_IN = "RUN_RABBITMQ_BLOCKED_TESTS"
+  RABBITMQ_CONNECTION_BLOCKED_TESTS_OPT_IN = "RUN_RABBITMQ_CONNECTION_BLOCKED_TESTS"
 
-  def skip_unless_rabbitmq_blocked_tests
-    return if %w[1 true].include?(ENV[RABBITMQ_BLOCKED_TESTS_OPT_IN])
+  def skip_unless_rabbitmq_connection_blocked_tests
+    return if %w[1 true].include?(ENV[RABBITMQ_CONNECTION_BLOCKED_TESTS_OPT_IN])
 
-    skip "set #{RABBITMQ_BLOCKED_TESTS_OPT_IN}=1 to run RabbitMQ Connection.Blocked tests"
+    skip "set #{RABBITMQ_CONNECTION_BLOCKED_TESTS_OPT_IN}=1 to run RabbitMQ Connection.Blocked tests"
   end
 end
 


### PR DESCRIPTION
`test_it_can_be_blocked` and `test_blocked_handler` exercise
RabbitMQ's `Connection.Blocked` extension via
`rabbitmqctl set_vm_memory_high_watermark`. LavinMQ doesn't implement
that extension; its low-resource back-pressure is a channel-level
`406 PRECONDITION_FAILED` instead.

Those RabbitMQ-only tests now use the explicit
`RUN_RABBITMQ_CONNECTION_BLOCKED_TESTS` opt-in, replacing the older
generic sudo flag. CI wires that opt-in through a
`connection_blocked_tests` matrix field and labels the test step with
`Connection.Blocked`.

Add `test_low_disk_blocks_publishing_with_precondition_failed`, the
LavinMQ analog: it boots a throwaway LavinMQ with `free_disk_min` above
real free space, then asserts a confirmed publish raises
`PreconditionFailed`. The LavinMQ flow-control test is self-contained,
sudo-free, opt-in via `RUN_LAVINMQ_FLOW_CONTROL_TESTS`, and skipped
when `lavinmq` is not on PATH.

The private LavinMQ startup helper now retries startup, bounds teardown,
uses a private clustering port to avoid LavinMQ 2.9.1 conflicts, and
includes per-attempt broker stdout/stderr in startup failures. README
documents both opt-ins, and Linux LavinMQ CI jobs enable the LavinMQ
flow-control test.