### PR TITLE
Add server-named queues and consumer tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Added: `Client#queue(nil)` and `Client#queue("")` declare a server-named queue and return a `Queue` with the broker-assigned name.
+- Added: `consumer_tag:` keyword argument on `Client#subscribe` and `Queue#subscribe`; pass nil or "" to let the broker generate the tag.
+
 ## [2.1.0] - 2026-06-23
 
 - Changed: Dropped support for Ruby 3.2 (now requires Ruby >= 3.3).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ amqp = AMQP::Client.new("amqp://localhost").start
 # Declares a durable queue
 myqueue = amqp.queue("myqueue")
 
+# Declares a server-named exclusive auto-delete queue
+temporary_queue = amqp.queue(nil)
+
 # Declares a topic exchange
 ex = amqp.topic_exchange("myexchange")
 
@@ -57,6 +60,11 @@ myqueue.subscribe do |msg|
   msg.ack
 rescue => e
   msg.reject
+end
+
+# Pass consumer_tag: to name a consumer, or nil/"" to let the broker name it
+consumer = myqueue.subscribe(consumer_tag: "worker-1") do |msg|
+  puts msg.body
 end
 
 # Publish directly to the queue, message will be serialized to json automatically

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -82,9 +82,9 @@ module AMQP
         @stopped = false
         initial_conn = connect(read_loop_thread: false)
         log_lifecycle(:info, "connected")
-        supervisor = Thread.new(initial_conn) do |conn| # rubocop:disable Metrics/BlockLength
+        supervisor = Thread.new(initial_conn) do |conn|
           Thread.current.abort_on_exception = true # Raising an unhandled exception is a bug
-          loop do # rubocop:disable Metrics/BlockLength
+          loop do
             break if @stopped
 
             unless conn
@@ -92,22 +92,7 @@ module AMQP
               log_lifecycle(:info, "reconnected")
             end
 
-            setup = Thread.new do
-              # restore connection in another thread, read_loop have to run
-              conn.channel(1) # reserve channel 1 for publishes
-              @consumers.each_value do |consumer|
-                ch = conn.channel
-                ch.basic_qos(consumer.prefetch)
-                consume_ok = ch.basic_consume(consumer.queue,
-                                              **consumer.basic_consume_args,
-                                              &consumer.block)
-                # Update the consumer with new channel and consume_ok metadata
-                consumer.update_consume_ok(consume_ok)
-              end
-              @connq << conn
-              # Remove consumers whose internal queues were already closed (e.g. cancelled during reconnect window)
-              @consumers.delete_if { |_, c| c.closed? }
-            end
+            setup = Thread.new { restore_connection(conn) }
             setup.name = thread_name("reconnect_setup")
             conn.read_loop # blocks until connection is closed, then reconnect
             log_lifecycle(:warn, "disconnected")
@@ -147,7 +132,7 @@ module AMQP
     # @!group High level objects
 
     # Declare a queue
-    # @param name [String] Name of the queue
+    # @param name [String, nil] Name of the queue. Pass nil or "" for a server-named queue.
     # @param durable [Boolean] If true the queue will survive broker restarts,
     #   messages in the queue will only survive if they are published as persistent
     # @param auto_delete [Boolean] If true the queue will be deleted when the last consumer stops consuming
@@ -161,7 +146,12 @@ module AMQP
     #   q = amqp.queue("foobar")
     #   q.publish("body")
     def queue(name, durable: true, auto_delete: false, exclusive: false, passive: false, arguments: {})
-      raise ArgumentError, "Currently only supports named, durable queues" if name.empty?
+      if server_named_queue?(name)
+        queue_ok = with_connection do |conn|
+          conn.channel(1).queue_declare("", durable:, auto_delete:, exclusive:, passive:, arguments:)
+        end
+        return Queue.new(self, queue_ok.queue_name)
+      end
 
       @queues.fetch(name) do
         with_connection do |conn|
@@ -316,10 +306,11 @@ module AMQP
     # @param on_cancel [Proc] Optional proc that will be called if the consumer is cancelled by the broker
     #   The proc will be called with the consumer tag as the only argument
     # @param arguments [Hash] Custom arguments to the consumer
+    # @param consumer_tag [String, nil] Custom consumer tag. Pass nil or "" to let the broker generate one.
     # @yield [Message] Delivered message from the queue
     # @return [Consumer] The consumer object, which can be used to cancel the consumer
     def subscribe(queue, exclusive: false, no_ack: false, prefetch: 1, worker_threads: 1,
-                  on_cancel: nil, arguments: {}, &blk)
+                  on_cancel: nil, arguments: {}, consumer_tag: nil, &blk)
       raise ArgumentError, "worker_threads have to be > 0" if worker_threads <= 0
 
       with_connection do |conn|
@@ -330,7 +321,9 @@ module AMQP
           @consumers.delete(consumer_id)
           on_cancel&.call(tag)
         end
-        basic_consume_args = { exclusive:, no_ack:, worker_threads:, on_cancel: on_cancel_proc, arguments: }
+        tag = consumer_tag.nil? ? "" : consumer_tag
+        basic_consume_args = { tag:, exclusive:, no_ack:, worker_threads:,
+                               on_cancel: on_cancel_proc, arguments: }
         consume_ok = ch.basic_consume(queue, **basic_consume_args, &blk)
         consumer = Consumer.new(client: self, channel_id: ch.id, id: consumer_id, block: blk,
                                 queue:, consume_ok:, prefetch:, basic_consume_args:)
@@ -614,6 +607,28 @@ module AMQP
 
     def lifecycle_prefix
       @name ? "AMQP::Client[#{@name}]" : "AMQP::Client"
+    end
+
+    def restore_connection(conn)
+      conn.channel(1)
+      # Snapshot because @consumers can mutate while recovery is running.
+      @consumers.values.each do |consumer| # rubocop:disable Style/HashEachMethods
+        ch = conn.channel
+        ch.basic_qos(consumer.prefetch)
+        consume_ok = ch.basic_consume(consumer.queue,
+                                      **consumer.basic_consume_args,
+                                      &consumer.block)
+        consumer.update_consume_ok(consume_ok, ch.id)
+        @consumers.delete(consumer.id) if consumer.closed?
+      rescue Error::ChannelClosed => e
+        log_lifecycle(:warn, "failed to resubscribe consumer for #{consumer.queue}: #{e.message}")
+        @consumers.delete(consumer.id)
+      end
+      @connq << conn
+    end
+
+    def server_named_queue?(name)
+      name.nil? || name.empty?
     end
 
     def default_content_properties

--- a/lib/amqp/client/consumer.rb
+++ b/lib/amqp/client/consumer.rb
@@ -39,8 +39,9 @@ module AMQP
 
       # Update the consumer with new metadata after reconnection
       # @api private
-      def update_consume_ok(consume_ok)
+      def update_consume_ok(consume_ok, channel_id)
         @consume_ok = consume_ok
+        @channel_id = channel_id
       end
     end
   end

--- a/lib/amqp/client/queue.rb
+++ b/lib/amqp/client/queue.rb
@@ -50,11 +50,13 @@ module AMQP
       # @param on_cancel [Proc] Optional proc that will be called if the consumer is cancelled by the broker
       #   The proc will be called with the consumer tag as the only argument
       # @param arguments [Hash] Custom arguments to the consumer
+      # @param consumer_tag [String, nil] Custom consumer tag. Pass nil or "" to let the broker generate one.
       # @yield [Message] Delivered message from the queue
       # @return [Consumer] The consumer object, which can be used to cancel the consumer
       def subscribe(no_ack: false, exclusive: false, prefetch: 1, worker_threads: 1, requeue_on_reject: true,
-                    on_cancel: nil, arguments: {})
-        @client.subscribe(@name, no_ack:, exclusive:, prefetch:, worker_threads:, on_cancel:, arguments:) do |message|
+                    on_cancel: nil, arguments: {}, consumer_tag: nil)
+        @client.subscribe(@name, no_ack:, exclusive:, prefetch:, worker_threads:,
+                                 on_cancel:, arguments:, consumer_tag:) do |message|
           yield message
           message.ack unless no_ack
         rescue StandardError => e

--- a/test/amqp/high_level_test.rb
+++ b/test/amqp/high_level_test.rb
@@ -75,6 +75,77 @@ class HighLevelTest < Minitest::Test
     @client.publish("", exchange: "amq.topic", routing_key: "foo.bar")
   end
 
+  def test_server_named_queue_gets_broker_assigned_name_from_empty_string
+    q = @client.queue("")
+
+    refute_empty q.name
+  ensure
+    q&.delete
+  end
+
+  def test_server_named_queue_gets_broker_assigned_name_from_nil
+    q = @client.queue(nil)
+
+    refute_empty q.name
+  ensure
+    q&.delete
+  end
+
+  def test_server_named_queue_publish_subscribe
+    msgs = Queue.new
+    q = @client.queue(nil)
+    q.subscribe(no_ack: true) { |msg| msgs << msg }
+
+    q.publish("hello")
+    msg = msgs.pop(timeout: 2)
+
+    assert_equal "hello", msg.body
+    assert_equal q.name, msg.routing_key
+  ensure
+    q&.delete
+  end
+
+  def test_server_named_queue_consumer_is_dropped_on_reconnect
+    q = @client.queue(nil)
+    consumer = q.subscribe(no_ack: true) { |_msg| nil }
+    result = Queue.new
+
+    thread = Thread.new do
+      q2 = @client.queue("test.server.named.after.reconnect", auto_delete: true)
+      q2.publish("ok")
+      result << q2.get(no_ack: true)&.body
+    ensure
+      q2&.delete
+    end
+    @client.with_connection(&:close)
+
+    assert_equal "ok", result.pop(timeout: 5)
+    refute_includes @client.instance_variable_get(:@consumers).values, consumer
+  ensure
+    thread&.kill&.join
+  end
+
+  def test_consumer_survives_reconnect_and_can_be_cancelled
+    q = @client.queue("test.consumer.survives.reconnect")
+    msgs = Queue.new
+    consumer = q.subscribe(no_ack: true) { |msg| msgs << msg }
+
+    @client.with_connection(&:close)
+
+    q.publish("after reconnect")
+    msg = msgs.pop(timeout: 5)
+
+    assert_equal "after reconnect", msg.body
+
+    consumer.cancel
+
+    q.publish("after cancel")
+
+    assert_nil msgs.pop(timeout: 1)
+  ensure
+    q&.delete
+  end
+
   def test_it_can_bind_unbind_exchanges
     msgs = Queue.new
     e = @client.exchange("test.exchange", type: "fanout", auto_delete: true)
@@ -457,6 +528,52 @@ class HighLevelTest < Minitest::Test
     consumer.cancel
   end
 
+  def test_subscribe_with_explicit_consumer_tag
+    q = @client.queue("test.consumer.tag.explicit", auto_delete: true)
+    msgs = Queue.new
+
+    consumer = q.subscribe(no_ack: true, consumer_tag: "my-named-consumer") do |msg|
+      msgs.push msg
+    end
+
+    assert_equal "my-named-consumer", consumer.tag
+
+    q.publish("hi")
+    msg = msgs.pop(timeout: 2)
+
+    assert_equal "my-named-consumer", msg.delivery_info.consumer_tag
+  ensure
+    consumer&.cancel
+    q&.delete
+  end
+
+  def test_client_subscribe_with_explicit_consumer_tag
+    q = @client.queue("test.consumer.tag.client.explicit", auto_delete: true)
+    msgs = Queue.new
+
+    consumer = @client.subscribe(q.name, no_ack: true, consumer_tag: "my-client-consumer") do |msg|
+      msgs.push msg
+    end
+
+    assert_equal "my-client-consumer", consumer.tag
+
+    q.publish("hi")
+    msg = msgs.pop(timeout: 2)
+
+    assert_equal "my-client-consumer", msg.delivery_info.consumer_tag
+  ensure
+    consumer&.cancel
+    q&.delete
+  end
+
+  def test_subscribe_with_broker_generated_consumer_tag_from_nil
+    assert_broker_generated_consumer_tag(nil)
+  end
+
+  def test_subscribe_with_broker_generated_consumer_tag_from_empty_string
+    assert_broker_generated_consumer_tag("")
+  end
+
   def test_passive_queue_raises_if_not_exists
     # Try to declare a queue with passive: true when it doesn't exist
     # Should raise an error because the queue doesn't exist
@@ -474,5 +591,26 @@ class HighLevelTest < Minitest::Test
     q2 = @client.queue("test.passive.exists", passive: true)
 
     assert_equal "test.passive.exists", q2.name
+  end
+
+  private
+
+  def assert_broker_generated_consumer_tag(consumer_tag)
+    q = @client.queue("test.consumer.tag.#{consumer_tag.nil? ? 'nil' : 'empty'}", auto_delete: true)
+    msgs = Queue.new
+
+    consumer = q.subscribe(no_ack: true, consumer_tag:) do |msg|
+      msgs.push msg
+    end
+
+    refute_empty consumer.tag
+
+    q.publish("hi")
+    msg = msgs.pop(timeout: 2)
+
+    assert_equal consumer.tag, msg.delivery_info.consumer_tag
+  ensure
+    consumer&.cancel
+    q&.delete
   end
 end


### PR DESCRIPTION
Support nil and empty string as requests for broker-generated queue names and consumer tags. Generated queue consumers are dropped during reconnect recovery if the old queue no longer exists, keeping the supervised client usable after reconnects.