### PR TITLE
Add on_connect hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added: `Client#queue(nil)` and `Client#queue("")` declare a server-named queue and return a `Queue` with the broker-assigned name.
 - Added: `consumer_tag:` keyword argument on `Client#subscribe` and `Queue#subscribe`; pass nil or "" to let the broker generate the tag.
+- Added: `on_connect:` constructor option for `AMQP::Client`. The callback runs with the client after each successful supervised connection or reconnection, after consumer recovery.
 
 ## [2.1.0] - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ ex.publish("my message", routing_key: "topic.foo", headers: { foo: "bar" })
 amqp.publish("an event", exchange: "amq.topic", routing_key: "my.event", content_encoding: "gzip")
 ```
 
+#### Reconnect setup hook
+
+Pass `on_connect:` when setup must run after every supervised connection or
+reconnection, after the client has recovered existing consumers:
+
+```ruby
+amqp = AMQP::Client.new("amqp://localhost", on_connect: ->(client) {
+  client.topic_exchange("events")
+}).start
+```
+
 #### Configuration
 
 Configure class-level defaults and enable built-in codecs using the `configure` method:

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -549,6 +549,8 @@ module AMQP
     # @!endgroup
     #
     def with_connection
+      return yield Thread.current[reserved_conn_key] if Thread.current[reserved_conn_key]
+
       conn = nil
       loop do
         conn = @connq.pop
@@ -627,17 +629,20 @@ module AMQP
         log_lifecycle(:warn, "failed to resubscribe consumer for #{consumer.queue}: #{e.message}")
         @consumers.delete(consumer.id)
       end
+      run_on_connect_hook(conn)
       @connq << conn
-      run_on_connect_hook
     end
 
     def server_named_queue?(name)
       name.nil? || name.empty?
     end
 
-    def run_on_connect_hook
+    # Thread-local (not an ivar) so the hook can call back into the client's API without
+    # deadlocking, and overlapping reconnects can't clobber each other's reservation.
+    def run_on_connect_hook(conn)
       return unless @on_connect
 
+      Thread.current[reserved_conn_key] = conn
       @on_connect.call(self)
     rescue StandardError => e
       if @logger
@@ -645,6 +650,13 @@ module AMQP
       else
         warn "AMQP-Client on_connect error: #{e.inspect}"
       end
+    ensure
+      Thread.current[reserved_conn_key] = nil
+    end
+
+    # Scoped per instance so a thread touching two Client objects can't cross-wire connections.
+    def reserved_conn_key
+      :"amqp_client_conn_#{object_id}"
     end
 
     def default_content_properties

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -35,9 +35,12 @@ module AMQP
     # @option options [#info, #warn, #error] logger (nil) Logger for {#start} lifecycle events
     #   (connected/reconnected/disconnected/reconnect errors). When nil, reconnect errors are
     #   written to stderr via Kernel#warn for backwards compatibility.
-    def initialize(uri = "", **options)
+    # @param on_connect [Proc, nil] Optional callback invoked with the client after each successful
+    #   (re)connection, after consumer recovery.
+    def initialize(uri = "", on_connect: nil, **options)
       @uri = uri
       @options = options
+      @on_connect = on_connect
       @logger = options[:logger]
       @name = parse_name(uri)
       @queues = {}
@@ -625,10 +628,23 @@ module AMQP
         @consumers.delete(consumer.id)
       end
       @connq << conn
+      run_on_connect_hook
     end
 
     def server_named_queue?(name)
       name.nil? || name.empty?
+    end
+
+    def run_on_connect_hook
+      return unless @on_connect
+
+      @on_connect.call(self)
+    rescue StandardError => e
+      if @logger
+        log_lifecycle(:warn, "on_connect raised: #{e.class}: #{e.message}")
+      else
+        warn "AMQP-Client on_connect error: #{e.inspect}"
+      end
     end
 
     def default_content_properties

--- a/test/amqp/high_level_test.rb
+++ b/test/amqp/high_level_test.rb
@@ -214,6 +214,19 @@ class HighLevelTest < Minitest::Test
     assert_equal :tick, counts.pop(timeout: 5)
   end
 
+  def test_on_connect_can_use_client_api_without_deadlocking
+    @client&.stop
+    @client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", on_connect: ->(c) { c.topic_exchange("oc.setup") }).start
+    x = @client.topic_exchange("oc.setup")
+    q = @client.queue("oc.setup.q", auto_delete: true).bind(x, binding_key: "foo")
+    x.publish("ping", routing_key: "foo")
+
+    assert_equal "ping", q.get(no_ack: true).body
+  ensure
+    q&.delete
+    x&.delete
+  end
+
   def test_on_connect_error_is_logged_and_connection_stays_usable
     io = StringIO.new
     logger = Logger.new(io)

--- a/test/amqp/high_level_test.rb
+++ b/test/amqp/high_level_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
+require "logger"
+require "stringio"
 require "zlib"
 
 class HighLevelTest < Minitest::Test
@@ -188,6 +190,50 @@ class HighLevelTest < Minitest::Test
     msg = msgs.pop
 
     assert msg.body, "bar"
+  ensure
+    q&.delete
+  end
+
+  def test_on_connect_fires_on_initial_connect
+    fired = Queue.new
+    @client&.stop
+    @client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", on_connect: ->(c) { fired << c }).start
+
+    assert_same @client, fired.pop(timeout: 2)
+  end
+
+  def test_on_connect_fires_on_every_reconnect
+    counts = Queue.new
+    @client&.stop
+    @client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", on_connect: ->(_c) { counts << :tick }).start
+
+    assert_equal :tick, counts.pop(timeout: 2)
+
+    @client.with_connection(&:close)
+
+    assert_equal :tick, counts.pop(timeout: 5)
+  end
+
+  def test_on_connect_error_is_logged_and_connection_stays_usable
+    io = StringIO.new
+    logger = Logger.new(io)
+    logger.formatter = ->(_severity, _time, _progname, message) { "#{message}\n" }
+    @client&.stop
+    @client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}",
+                               logger:,
+                               on_connect: ->(_c) { raise "forced setup failure" }).start
+
+    q = @client.queue("test.on_connect.raise.usable", auto_delete: true)
+    q.publish("ping")
+
+    msg = q.get(no_ack: true)
+
+    assert_equal "ping", msg.body
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+    sleep 0.01 until io.string.include?("on_connect raised") ||
+                     Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+    assert_includes io.string, "AMQP::Client: on_connect raised: RuntimeError: forced setup failure"
   ensure
     q&.delete
   end


### PR DESCRIPTION
Run an optional callback after each supervised connection has been restored. The hook receives the high-level client, runs after consumer recovery, and is rescued so a setup failure is logged without making the connection unusable.