### PR TITLE
Use private LavinMQ control sockets in TLS tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,14 +198,14 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ### TLS tests
 
-`rake test` excludes the TLS tests because they need a broker with TLS enabled. `bin/test-tls` runs them against a throwaway broker without disturbing anything you already have set up: it generates a self-signed certificate, starts the broker as your user from a temporary directory on non-default ports (25672/25671), runs the `_tls` tests, then shuts it down. With no argument it tests both brokers in turn:
+`rake test` excludes the TLS tests because they need a broker with TLS enabled. `bin/test-tls` runs them against a throwaway broker without disturbing anything you already have set up: it generates a self-signed certificate, starts the broker as your user from a temporary directory on non-default ports (21672/21671), runs the `_tls` tests, then shuts it down. With no argument it tests both brokers in turn:
 
 ```bash
 bin/test-tls            # both brokers
 bin/test-tls lavinmq    # or a single broker: lavinmq or rabbitmq
 ```
 
-It never uses the system service, writes under `/etc`, or stops a broker you are already running, so it is safe to use alongside a local RabbitMQ/LavinMQ on the default ports. (LavinMQ is one exception: it hardcodes its control socket at `/tmp/lavinmqctl.sock`, which the script must clear, so a LavinMQ you already have running keeps serving AMQP but loses its `lavinmqctl` socket until restarted.) The broker is installed if missing (LavinMQ from CloudAMQP's packagecloud repo, which is removed again if the script added it); that install is the only step needing `sudo`. An installed broker package is left in place afterwards — only the apt repo is cleaned up. The certificate directory is `CERT_DIR` (default `/tmp/amqp-tls`) and the ports are `TEST_AMQP_PORT`/`TEST_AMQPS_PORT`. Requires a Linux host. The TLS jobs in the CI workflow call this same script, so CI exercises it too.
+It never uses the system service, writes under `/etc`, stops a broker you are already running, or touches the default LavinMQ control socket. The broker is installed if missing (LavinMQ from CloudAMQP's packagecloud repo, which is removed again if the script added it); that install is the only step needing `sudo`. An installed broker package is left in place afterwards — only the apt repo is cleaned up. The certificate directory is `CERT_DIR` (default `/tmp/amqp-tls`) and the ports are `TEST_AMQP_PORT`/`TEST_AMQPS_PORT`. Requires a Linux host. The TLS jobs in the CI workflow call this same script, so CI exercises it too.
 
 ### Release Process
 

--- a/bin/test-tls
+++ b/bin/test-tls
@@ -24,7 +24,7 @@
 # localhost) in its SAN for the hostname check. (One test still passes
 # verify_peer: false to cover that path too.) The certificate lives in a
 # user-owned directory (CERT_DIR, default /tmp/amqp-tls). The ports default to
-# 25672 (plaintext) / 25671 (TLS) and can be overridden with TEST_AMQP_PORT /
+# 21672 (plaintext) / 21671 (TLS) and can be overridden with TEST_AMQP_PORT /
 # TEST_AMQPS_PORT.
 set -euo pipefail
 
@@ -181,18 +181,13 @@ start_lavinmq() {
   broker_kind=lavinmq
   work_dir="$(mktemp -d)"
   : >"$work_dir/lavinmq.ini" # empty config so /etc/lavinmq/lavinmq.ini is ignored
-  # LavinMQ hardcodes its control socket at /tmp/lavinmqctl.sock and aborts at
-  # startup if it can't (re)create it. A LavinMQ already running as another user
-  # owns it, and sticky /tmp won't let us delete it -- so clear it first, using
-  # sudo only if a foreign owner forces it. A running instance keeps its open
-  # socket (only its path-based lavinmqctl is affected), so this doesn't stop it.
-  rm -f /tmp/lavinmqctl.sock 2>/dev/null || $SUDO rm -f /tmp/lavinmqctl.sock 2>/dev/null || true
   # Move *every* listener to a private port (LavinMQ aborts if any one can't
   # bind), so we never clash with a LavinMQ already running on the defaults.
   lavinmq -c "$work_dir/lavinmq.ini" -D "$work_dir/data" --bind 127.0.0.1 \
     --amqp-port "$amqp_port" --amqps-port "$amqps_port" \
     --http-port 21673 --https-port 21674 --metrics-http-port 21675 \
     --mqtt-port 21676 --mqtts-port 21677 \
+    --control-unix-path "$work_dir/lavinmqctl.sock" \
     --cert "$CERT" --key "$KEY" >"$work_dir/broker.log" 2>&1 &
   broker_pid=$!
 }
@@ -268,8 +263,6 @@ stop_broker() {
   if [ "$broker_kind" = rabbitmq ]; then
     ERL_EPMD_PORT="$epmd_port" epmd -kill >/dev/null 2>&1 || true
   fi
-  # Remove the control socket we created (see start_lavinmq).
-  [ "$broker_kind" = lavinmq ] && rm -f /tmp/lavinmqctl.sock 2>/dev/null || true
   broker_pid=""
   [ -n "$work_dir" ] && rm -rf "$work_dir"
   work_dir=""


### PR DESCRIPTION
LavinMQ 2.9.0 supports `--control-unix-path`, so the TLS runner can isolate its throwaway broker without deleting the default `/tmp/lavinmqctl.sock`. This keeps a separately running LavinMQ instance usable while the TLS tests run.

The script already defaults to ports 21672 and 21671; update the documentation and header comment that still claimed 25672 and 25671.

## Changes

- Pass a per-workdir control socket path to `lavinmq`.
- Remove the old default-socket deletion and cleanup.
- Document the actual TLS test default ports.