### PR TITLE
test: clean up auto-delete queues in get/passive tests

### DIFF
--- a/test/amqp/high_level_test.rb
+++ b/test/amqp/high_level_test.rb
@@ -385,6 +385,8 @@ class HighLevelTest < Minitest::Test
     assert_instance_of AMQP::Client::Message, msg
     assert_equal "test message body", msg.body
     assert_equal "test.get.message", msg.routing_key
+  ensure
+    q&.delete
   end
 
   def test_queue_get_returns_nil_when_empty
@@ -393,6 +395,8 @@ class HighLevelTest < Minitest::Test
     msg = q.get(no_ack: true)
 
     assert_nil msg, "Expected get to return nil for empty queue"
+  ensure
+    q&.delete
   end
 
   def test_client_get_method
@@ -403,6 +407,8 @@ class HighLevelTest < Minitest::Test
 
     assert_instance_of AMQP::Client::Message, msg
     assert_equal "client get test", msg.body
+  ensure
+    q&.delete
   end
 
   def test_exclusive_queue_deleted_on_connection_close
@@ -474,5 +480,7 @@ class HighLevelTest < Minitest::Test
     q2 = @client.queue("test.passive.exists", passive: true)
 
     assert_equal "test.passive.exists", q2.name
+  ensure
+    q&.delete
   end
 end


### PR DESCRIPTION
These four tests create auto-delete queues but never subscribe to them. Auto-delete queues are only removed after having had at least one consumer, so queues that only use get/passive declares are left behind on the broker:

  test.get.message, test.get.empty, test.client.get, test.passive.exists

Add an ensure `q&.delete` to each, matching the cleanup convention used by the rest of the file.