### PR TITLE
Move throwaway LavinMQ clustering listener to a private port

### DIFF
--- a/bin/test-tls
+++ b/bin/test-tls
@@ -186,7 +186,7 @@ start_lavinmq() {
   lavinmq -c "$work_dir/lavinmq.ini" -D "$work_dir/data" --bind 127.0.0.1 \
     --amqp-port "$amqp_port" --amqps-port "$amqps_port" \
     --http-port 21673 --https-port 21674 --metrics-http-port 21675 \
-    --mqtt-port 21676 --mqtts-port 21677 \
+    --mqtt-port 21676 --mqtts-port 21677 --clustering-port 21678 \
     --control-unix-path "$work_dir/lavinmqctl.sock" \
     --cert "$CERT" --key "$KEY" >"$work_dir/broker.log" 2>&1 &
   broker_pid=$!


### PR DESCRIPTION
Since LavinMQ 2.9.1 (cloudamqp/lavinmq#2114) the clustering listener on port 5679 is bound eagerly at startup and a bind conflict is fatal. The TLS runner's throwaway broker moved every other listener off the defaults but not this one, so it collided with the LavinMQ started by the CI action and aborted with "Could not bind to '127.0.0.1:5679'". Pin it to a private port like the rest.