### PR TITLE
CI: Require jruby-openssl >= 0.19.0 on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ gemspec
 
 gem "benchmark"
 gem "bunny"
+# JRuby 10.1.1.0 bundles jruby-openssl 0.16.2, where SSLSocket#sysread flushes the
+# shared netWriteData buffer without a lock, racing our writer threads against the
+# read_loop thread and corrupting the TLS stream. 0.19.0 guards it with a writeLock.
+gem "jruby-openssl", ">= 0.19.0", platforms: :jruby
 gem "logger"
 gem "minitest"
 gem "minitest-mock"


### PR DESCRIPTION
The TLS tests fail on JRuby 10.1.1.0, which bundles jruby-openssl 0.16.2.

In 0.16.0 the SSL read path started flushing the shared write buffer (jruby/jruby-openssl@06692c7, "SSL write loss on non-blocking partial flush"). Nothing locks that buffer, so our read_loop thread and the threads publishing on the same connection trip over each other and corrupt the TLS stream, dropping the connection mid-publish.

0.19.0 guards the buffer with a lock (jruby/jruby-openssl@7b7421b, "serialize SSL writes (concurrent read/write)"), so ask for at least that version. It supports JRuby 9.2 and up, so older JRubies can use it too -- verified that both JRuby 10.1.1.0 and 10.1.0.0 pass the full suite with it.

MRI and TruffleRuby were never affected.

---

Another option is to pin JRuby on CI, but I deemed this to be slightly "less worse". Once JRuby is released with a `jruby-openssl` version that includes the fix we can remove it from the `Gemfile`.

Note that this does not fix anything for end-users that would happen to run on JRuby 10.1.1.0, clients will need to do the same thing (adding `jruby-openssl` to their Gemfiles), but I find that acceptable for now.