### PR TITLE
Bump codeql-action to v4.37.7 and group its updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
       # the 1st and 15th of each month.
       interval: "cron"
       cronjob: "0 6 1,15 * *"
+    groups:
+      # codeql-action/init and codeql-action/analyze are separate dependencies to
+      # Dependabot, but analyze refuses to load a config file written by a
+      # different version of init, so they must be bumped in the same PR.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -38,4 +38,4 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7


### PR DESCRIPTION
Dependabot treats github/codeql-action/init and github/codeql-action/analyze
as separate dependencies and opened one PR for each (#126, #128). But analyze
fails when the config file it loads was written by a different version of init:

  Loaded a configuration file for version '4.36.2', but running version '4.37.6'

so each PR fails CodeQL on its own and only works merged together. Bump both to
v4.37.7 in one commit, and add a Dependabot group so future codeql-action
updates always arrive in a single PR.

Supersedes #126 and #128.
