### PR TITLE
Mention supported brokers in README and gem description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modern AMQP 0-9-1 Ruby client. Very fast (just as fast as the Java client, and >2x than other Ruby clients), fully thread-safe, blocking operations and straight-forward error handling.
 
-It works with any broker that speaks AMQP 0-9-1 — RabbitMQ, LavinMQ and Apache Qpid Broker-J — whether self-hosted or managed, such as on CloudAMQP or Amazon MQ.
+It works with any broker that speaks AMQP 0-9-1, such as RabbitMQ, LavinMQ and Apache Qpid Broker-J, whether self-hosted or managed on CloudAMQP or Amazon MQ.
 
 It's small, and without any dependencies. Other Ruby clients are about several times bigger. But without trading functionality.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A modern AMQP 0-9-1 Ruby client. Very fast (just as fast as the Java client, and >2x than other Ruby clients), fully thread-safe, blocking operations and straight-forward error handling.
 
+It works with any broker that speaks AMQP 0-9-1, including RabbitMQ, LavinMQ, Amazon MQ for RabbitMQ, CloudAMQP and Apache Qpid Broker-J.
+
 It's small, and without any dependencies. Other Ruby clients are about several times bigger. But without trading functionality.
 
 It's safe by default, messages are published as persistent, and is waiting for confirmation from the broker. That can of course be disabled if performance is a priority.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modern AMQP 0-9-1 Ruby client. Very fast (just as fast as the Java client, and >2x than other Ruby clients), fully thread-safe, blocking operations and straight-forward error handling.
 
-It works with any broker that speaks AMQP 0-9-1, including RabbitMQ, LavinMQ, Amazon MQ for RabbitMQ, CloudAMQP and Apache Qpid Broker-J.
+It works with any broker that speaks AMQP 0-9-1 — RabbitMQ, LavinMQ and Apache Qpid Broker-J — whether self-hosted or managed, such as on CloudAMQP or Amazon MQ.
 
 It's small, and without any dependencies. Other Ruby clients are about several times bigger. But without trading functionality.
 

--- a/amqp-client.gemspec
+++ b/amqp-client.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["team@cloudamqp.com"]
 
   spec.summary       = "AMQP 0-9-1 client"
-  spec.description   = "Modern AMQP 0-9-1 Ruby client"
+  spec.description   = "A modern, fast, thread-safe and dependency-free AMQP 0-9-1 Ruby client, for RabbitMQ, LavinMQ and any other AMQP 0-9-1 broker"
   spec.homepage      = "https://github.com/cloudamqp/amqp-client.rb"
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")

--- a/amqp-client.gemspec
+++ b/amqp-client.gemspec
@@ -8,8 +8,10 @@ Gem::Specification.new do |spec|
   spec.authors       = ["CloudAMQP"]
   spec.email         = ["team@cloudamqp.com"]
 
-  spec.summary       = "AMQP 0-9-1 client"
-  spec.description   = "A modern, fast, thread-safe and dependency-free AMQP 0-9-1 Ruby client, for RabbitMQ, LavinMQ and any other AMQP 0-9-1 broker"
+  spec.summary       = "Modern, fast and dependency-free AMQP 0-9-1 Ruby client for RabbitMQ and LavinMQ"
+  spec.description   = "A modern AMQP 0-9-1 Ruby client for RabbitMQ, LavinMQ and any other AMQP 0-9-1 broker. " \
+                       "Very fast, fully thread-safe, with blocking operations, straight-forward " \
+                       "error handling and no dependencies."
   spec.homepage      = "https://github.com/cloudamqp/amqp-client.rb"
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
@@ -17,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "#{spec.homepage}.git"
   spec.metadata["changelog_uri"] = "https://github.com/cloudamqp/amqp-client.rb/blob/main/CHANGELOG.md"
+  spec.metadata["documentation_uri"] = "https://cloudamqp.github.io/amqp-client.rb/"
+  spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files         = Dir["LICENSE.txt", "lib/**/*.rb"]


### PR DESCRIPTION
Make it clearer that the client works with RabbitMQ, LavinMQ and other
AMQP 0-9-1 brokers, so people searching for a broker-specific Ruby client
find it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NSJdZ2ujL92zU6ETTXXDZJ