### PR TITLE
Add max_retries and on_failed to AMQP::Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added: `Client#queue(nil)` and `Client#queue("")` declare a server-named queue and return a `Queue` with the broker-assigned name.
 - Added: `consumer_tag:` keyword argument on `Client#subscribe` and `Queue#subscribe`; pass nil or "" to let the broker generate the tag.
 - Added: `on_connect:` constructor option for `AMQP::Client`. The callback runs with the client after each successful supervised connection or reconnection, after consumer recovery.
+- Added: `max_retries:` and `on_failed:` constructor options for `AMQP::Client`. When `max_retries:` is set, the supervisor gives up and calls `on_failed:` with the triggering error after that many consecutive failed reconnect attempts, instead of retrying forever.
 
 ## [2.1.0] - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ amqp = AMQP::Client.new("amqp://localhost", on_connect: ->(client) {
 }).start
 ```
 
+Pass `max_retries:` and `on_failed:` to stop retrying and get notified after a
+run of consecutive failed reconnect attempts, instead of retrying forever:
+
+```ruby
+amqp = AMQP::Client.new("amqp://localhost",
+  max_retries: 10,
+  on_failed: ->(err) { logger.error("AMQP gave up reconnecting: #{err}") }).start
+```
+
 #### Configuration
 
 Configure class-level defaults and enable built-in codecs using the `configure` method:

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -37,10 +37,17 @@ module AMQP
     #   written to stderr via Kernel#warn for backwards compatibility.
     # @param on_connect [Proc, nil] Optional callback invoked with the client after each successful
     #   (re)connection, after consumer recovery.
-    def initialize(uri = "", on_connect: nil, **options)
+    # @param on_failed [Proc, nil] Optional callback invoked with the triggering error once
+    #   reconnection has given up after max_retries consecutive failed attempts. The supervisor
+    #   stops after calling it, same as after {#stop}.
+    # @param max_retries [Integer, nil] Number of consecutive reconnect attempts to allow before
+    #   giving up and calling on_failed. Defaults to nil, retrying forever.
+    def initialize(uri = "", on_connect: nil, on_failed: nil, max_retries: nil, **options)
       @uri = uri
       @options = options
       @on_connect = on_connect
+      @on_failed = on_failed
+      @max_retries = max_retries
       @logger = options[:logger]
       @name = parse_name(uri)
       @queues = {}
@@ -87,11 +94,13 @@ module AMQP
         log_lifecycle(:info, "connected")
         supervisor = Thread.new(initial_conn) do |conn|
           Thread.current.abort_on_exception = true # Raising an unhandled exception is a bug
+          reconnect_attempts = 0
           loop do
             break if @stopped
 
             unless conn
               conn = connect(read_loop_thread: false)
+              reconnect_attempts = 0
               log_lifecycle(:info, "reconnected")
             end
 
@@ -100,6 +109,9 @@ module AMQP
             conn.read_loop # blocks until connection is closed, then reconnect
             log_lifecycle(:warn, "disconnected")
           rescue Error => e
+            reconnect_attempts += 1
+            break if give_up_reconnecting?(reconnect_attempts, e)
+
             log_reconnect_error(e)
             sleep @options[:reconnect_interval] || 1
           ensure
@@ -606,6 +618,15 @@ module AMQP
       end
     end
 
+    def log_give_up(reconnect_attempts, err)
+      message = "gave up reconnecting after #{reconnect_attempts} attempts: #{err.inspect}"
+      if @logger
+        @logger.error("#{lifecycle_prefix}: #{message}")
+      else
+        warn "AMQP-Client #{message}"
+      end
+    end
+
     def thread_name(role)
       @name ? "amqp.#{role}[#{@name}]" : "amqp.#{role}"
     end
@@ -657,6 +678,29 @@ module AMQP
     # Scoped per instance so a thread touching two Client objects can't cross-wire connections.
     def reserved_conn_key
       :"amqp_client_conn_#{object_id}"
+    end
+
+    # Reports whether the supervisor should give up after this reconnect failure, logging and
+    # calling on_failed as a side effect when it does.
+    def give_up_reconnecting?(reconnect_attempts, err)
+      return false unless @max_retries && reconnect_attempts > @max_retries
+
+      @stopped = true
+      log_give_up(reconnect_attempts, err)
+      run_on_failed_hook(err)
+      true
+    end
+
+    def run_on_failed_hook(err)
+      return unless @on_failed
+
+      @on_failed.call(err)
+    rescue StandardError => e
+      if @logger
+        log_lifecycle(:warn, "on_failed raised: #{e.class}: #{e.message}")
+      else
+        warn "AMQP-Client on_failed error: #{e.inspect}"
+      end
     end
 
     def default_content_properties

--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -43,6 +43,10 @@ module AMQP
     # @param max_retries [Integer, nil] Number of consecutive reconnect attempts to allow before
     #   giving up and calling on_failed. Defaults to nil, retrying forever.
     def initialize(uri = "", on_connect: nil, on_failed: nil, max_retries: nil, **options)
+      if max_retries && (!max_retries.is_a?(Integer) || max_retries.negative?)
+        raise ArgumentError, "max_retries must be a non-negative Integer or nil"
+      end
+
       @uri = uri
       @options = options
       @on_connect = on_connect
@@ -683,7 +687,7 @@ module AMQP
     # Reports whether the supervisor should give up after this reconnect failure, logging and
     # calling on_failed as a side effect when it does.
     def give_up_reconnecting?(reconnect_attempts, err)
-      return false unless @max_retries && reconnect_attempts > @max_retries
+      return false unless @max_retries && reconnect_attempts >= @max_retries
 
       @stopped = true
       log_give_up(reconnect_attempts, err)

--- a/test/amqp/on_failed_test.rb
+++ b/test/amqp/on_failed_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "logger"
+require "stringio"
+
+class OnFailedTest < Minitest::Test
+  def teardown
+    @client&.stop
+  end
+
+  def test_on_failed_fires_after_max_retries_and_stops_supervisor
+    failed = Queue.new
+    @client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", max_retries: 2, reconnect_interval: 0,
+                                                           on_failed: ->(err) { failed << err })
+    original_connect = @client.method(:connect)
+    attempts = 0
+    replacement = lambda { |**kwargs|
+      attempts += 1
+      raise AMQP::Client::Error, "simulated failure" if attempts > 1
+
+      original_connect.call(**kwargs)
+    }
+
+    @client.stub(:connect, replacement) do
+      @client.start
+      @client.with_connection(&:close)
+
+      err = failed.pop(timeout: 2)
+
+      assert_match(/simulated failure/, err.message)
+    end
+
+    refute_predicate @client, :started?
+  end
+
+  def test_on_failed_error_is_logged
+    io = StringIO.new
+    logger = Logger.new(io)
+    logger.formatter = ->(_severity, _time, _progname, message) { "#{message}\n" }
+    @client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", logger:, max_retries: 0, reconnect_interval: 0,
+                                                           on_failed: ->(_err) { raise "forced on_failed failure" })
+    original_connect = @client.method(:connect)
+    attempts = 0
+    replacement = lambda { |**kwargs|
+      attempts += 1
+      raise AMQP::Client::Error, "simulated failure" if attempts > 1
+
+      original_connect.call(**kwargs)
+    }
+
+    @client.stub(:connect, replacement) do
+      @client.start
+      @client.with_connection(&:close)
+
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+      sleep 0.01 until io.string.include?("on_failed raised") ||
+                       Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+    end
+
+    assert_includes io.string, "AMQP::Client: on_failed raised: RuntimeError: forced on_failed failure"
+  end
+
+  def test_reconnect_attempts_reset_after_a_successful_reconnect
+    failed = Queue.new
+    @client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", max_retries: 1, reconnect_interval: 0,
+                                                           on_failed: ->(err) { failed << err })
+    original_connect = @client.method(:connect)
+    fail_next = false
+    replacement = lambda { |**kwargs|
+      if fail_next
+        fail_next = false
+        raise AMQP::Client::Error, "simulated failure"
+      end
+      original_connect.call(**kwargs)
+    }
+
+    @client.stub(:connect, replacement) do
+      @client.start
+
+      2.times do
+        fail_next = true
+        @client.with_connection(&:close)
+        @client.with_connection { _1 } # wait for the single-retry reconnect to settle
+      end
+    end
+
+    assert_predicate @client, :started?
+    assert_predicate failed, :empty?
+  end
+end

--- a/test/amqp/on_failed_test.rb
+++ b/test/amqp/on_failed_test.rb
@@ -9,6 +9,14 @@ class OnFailedTest < Minitest::Test
     @client&.stop
   end
 
+  def test_max_retries_rejects_non_integer
+    assert_raises(ArgumentError) { AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", max_retries: "3") }
+  end
+
+  def test_max_retries_rejects_negative_integer
+    assert_raises(ArgumentError) { AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", max_retries: -1) }
+  end
+
   def test_on_failed_fires_after_max_retries_and_stops_supervisor
     failed = Queue.new
     @client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", max_retries: 2, reconnect_interval: 0,
@@ -29,6 +37,8 @@ class OnFailedTest < Minitest::Test
       err = failed.pop(timeout: 2)
 
       assert_match(/simulated failure/, err.message)
+      # 1 initial connect + 2 failed reconnect attempts (max_retries) before giving up
+      assert_equal 3, attempts
     end
 
     refute_predicate @client, :started?
@@ -63,7 +73,10 @@ class OnFailedTest < Minitest::Test
 
   def test_reconnect_attempts_reset_after_a_successful_reconnect
     failed = Queue.new
-    @client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", max_retries: 1, reconnect_interval: 0,
+    # max_retries: 2 tolerates one failed attempt per cycle below without giving up; if the
+    # counter didn't reset after a successful reconnect, the second cycle's failure would push
+    # the (wrongly accumulated) count over the limit and trigger a spurious give-up.
+    @client = AMQP::Client.new("amqp://#{TEST_AMQP_HOST}", max_retries: 2, reconnect_interval: 0,
                                                            on_failed: ->(err) { failed << err })
     original_connect = @client.method(:connect)
     fail_next = false


### PR DESCRIPTION
## Background

#83 asked for both `on_connect:` and `on_failed:` callbacks on the supervised, reconnecting `AMQP::Client`. `on_connect:` shipped, but the reconnect loop still retries forever with no way to signal a permanent failure, so `on_failed:` was left out.

Bunny has the same shape (`recovery_attempts` plus a `:recovery_attempts_exhausted` callback), and so does the amqp-client.js sibling (`maxRetries`/`onfailed`), so there's precedent for capping retries rather than retrying forever by default.

## Summary

- Added `max_retries:` and `on_failed:` constructor options to `AMQP::Client`.
- When `max_retries:` is set, the supervisor gives up after that many consecutive failed reconnect attempts, calls `on_failed:` with the triggering error, and stops (same as after `#stop`).
- The attempt counter resets after every successful reconnect, so isolated blips don't accumulate toward the cap.
- Default is `max_retries: nil`, unlimited retries, unchanged from current behavior.
- A raised `on_failed:` callback is caught and logged, mirroring how `on_connect:` errors are handled.

## Test plan

- [x] `bundle exec rake test` (one pre-existing, unrelated failure: `test_it_can_update_secret`, fails the same way on `main`)
- [x] `bundle exec rubocop`
- [x] New tests in `test/amqp/on_failed_test.rb` cover: giving up after `max_retries` and stopping the supervisor, a raised `on_failed:` being logged, and the attempt counter resetting after a successful reconnect