### PR TITLE
Make update-secret test tolerant of older LavinMQ versions

### DIFF
--- a/test/amqp/client_lifecycle_test.rb
+++ b/test/amqp/client_lifecycle_test.rb
@@ -567,8 +567,11 @@ class AMQPClientLifecycleTest < Minitest::Test
   def test_it_can_update_secret
     @connection.update_secret "secret", reason: "testing"
   rescue AMQP::Client::Error::ConnectionClosed => e
-    # LavinMQ only supports update-secret with the OAuth2 authentication mechanism
-    skip "Broker requires OAuth2 for update-secret" if e.message.include?("update-secret not supported")
+    # LavinMQ only supports update-secret with the OAuth2 authentication mechanism. Newer versions
+    # close with a friendly ACCESS_REFUSED reason; older ones (< 2.9) don't recognize the frame at
+    # all and close with a bare UNEXPECTED_FRAME. Match on the culprit method (10/70 =
+    # Connection.UpdateSecret), which both close frames carry, instead of the reason text.
+    skip "Broker rejected update-secret" if e.message.end_with?("(10/70)")
     raise
   end
 


### PR DESCRIPTION
## Background

`test_it_can_update_secret` was failing (not skipping) against a LavinMQ install older than v2.7.0: it closes the connection with a bare `505 UNEXPECTED_FRAME` instead of the friendly `403 ACCESS_REFUSED "update-secret not supported..."` that newer LavinMQ sends, because older versions don't recognize the `UpdateSecret` frame at all outside OAuth2. The test's skip check only matched the newer wording.

The friendly rejection was added in cloudamqp/lavinmq#1632 (OAuth2 support, fixing cloudamqp/lavinmq#857), first released in LavinMQ v2.7.0.

## Summary

- The skip check now matches on the culprit method in the close frame (`10/70`, `Connection.UpdateSecret`) instead of the reason text, since both the old and new close frames carry it regardless of the reason string.

## Test plan

- [x] `bundle exec rake test` (0 failures, 5 skips, including this one)
- [x] `bundle exec rubocop`